### PR TITLE
Fix P0 Android demo blockers (#7-#12)

### DIFF
--- a/shelfscan/androidApp/build.gradle.kts
+++ b/shelfscan/androidApp/build.gradle.kts
@@ -70,7 +70,6 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
     implementation(libs.compose.activity)
-    implementation(libs.appcompat)
 
     // CameraX
     implementation(libs.camerax.core)

--- a/shelfscan/androidApp/src/androidTest/kotlin/com/shelfscan/android/image/OcrBasedSpineDetectorTest.kt
+++ b/shelfscan/androidApp/src/androidTest/kotlin/com/shelfscan/android/image/OcrBasedSpineDetectorTest.kt
@@ -1,6 +1,9 @@
 package com.shelfscan.android.image
 
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.shelfscan.android.test.TestImageLoader
 import com.shelfscan.shared.core.model.CapturedImage
 import kotlinx.coroutines.runBlocking
@@ -14,13 +17,15 @@ import kotlin.test.assertTrue
 class OcrBasedSpineDetectorTest {
 
     private lateinit var detector: OcrBasedSpineDetector
+    private lateinit var recognizer: TextRecognizer
     private lateinit var imageLoader: TestImageLoader
     private lateinit var testImagePath: String
 
     @Before
     fun setUp() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        detector = OcrBasedSpineDetector(context)
+        recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+        detector = OcrBasedSpineDetector(context, recognizer)
         imageLoader = TestImageLoader()
         testImagePath = imageLoader.loadAsset("test_bookshelf.jpg")
     }
@@ -28,6 +33,7 @@ class OcrBasedSpineDetectorTest {
     @After
     fun tearDown() {
         imageLoader.cleanup()
+        recognizer.close()
     }
 
     @Test

--- a/shelfscan/androidApp/src/androidTest/kotlin/com/shelfscan/android/ocr/MlKitOcrAdapterTest.kt
+++ b/shelfscan/androidApp/src/androidTest/kotlin/com/shelfscan/android/ocr/MlKitOcrAdapterTest.kt
@@ -1,6 +1,9 @@
 package com.shelfscan.android.ocr
 
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.shelfscan.android.test.TestImageLoader
 import com.shelfscan.shared.core.model.ProcessedImage
 import kotlinx.coroutines.runBlocking
@@ -13,13 +16,15 @@ import kotlin.test.assertTrue
 class MlKitOcrAdapterTest {
 
     private lateinit var adapter: MlKitOcrAdapter
+    private lateinit var recognizer: TextRecognizer
     private lateinit var imageLoader: TestImageLoader
     private lateinit var testImagePath: String
 
     @Before
     fun setUp() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        adapter = MlKitOcrAdapter(context)
+        recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+        adapter = MlKitOcrAdapter(context, recognizer)
         imageLoader = TestImageLoader()
         testImagePath = imageLoader.loadAsset("test_bookshelf.jpg")
     }
@@ -27,6 +32,7 @@ class MlKitOcrAdapterTest {
     @After
     fun tearDown() {
         imageLoader.cleanup()
+        recognizer.close()
     }
 
     @Test

--- a/shelfscan/androidApp/src/main/AndroidManifest.xml
+++ b/shelfscan/androidApp/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
+        android:name=".ShelfScanApplication"
         android:label="ShelfScan"
         android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
         <activity

--- a/shelfscan/androidApp/src/main/AndroidManifest.xml
+++ b/shelfscan/androidApp/src/main/AndroidManifest.xml
@@ -7,11 +7,14 @@
     <application
         android:name=".ShelfScanApplication"
         android:label="ShelfScan"
-        android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.ShelfScan">
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+            android:theme="@style/Theme.ShelfScan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/MainActivity.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/MainActivity.kt
@@ -8,10 +8,9 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -20,28 +19,17 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.lifecycleScope
 import com.shelfscan.android.camera.CameraXAdapter
-import com.shelfscan.android.ocr.MlKitOcrAdapter
+import com.shelfscan.android.ui.ReviewScreen
+import com.shelfscan.android.viewmodel.AndroidReviewViewModel
+import com.shelfscan.android.viewmodel.AndroidScanViewModel
 import com.shelfscan.shared.core.model.ScanStatus
-import com.shelfscan.shared.data.metadata.OpenLibraryMetadataLookupService
-import com.shelfscan.shared.data.repository.DefaultCollectionRepository
-import com.shelfscan.shared.data.repository.DefaultScanRepository
-import com.shelfscan.shared.domain.scan.ProcessCapturedImageUseCase
 import com.shelfscan.shared.feature.review.ReviewAction
-import com.shelfscan.shared.feature.review.ReviewState
 import com.shelfscan.shared.feature.review.ReviewViewModel
 import com.shelfscan.shared.feature.scan.ScanAction
 import com.shelfscan.shared.feature.scan.ScanState
 import com.shelfscan.shared.feature.scan.ScanViewModel
-import com.shelfscan.android.image.OcrBasedSpineDetector
-import com.shelfscan.android.ui.ReviewScreen
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.okhttp.OkHttp
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
 
 class MainViewModel : ViewModel() {
     var cameraPermissionGranted by mutableStateOf(false)
@@ -49,11 +37,10 @@ class MainViewModel : ViewModel() {
 
 class MainActivity : ComponentActivity() {
     private val mainViewModel: MainViewModel by viewModels()
+    private val androidScanViewModel: AndroidScanViewModel by viewModels()
+    private val androidReviewViewModel: AndroidReviewViewModel by viewModels()
 
     private lateinit var cameraAdapter: CameraXAdapter
-    private lateinit var scanViewModel: ScanViewModel
-    private lateinit var reviewViewModel: ReviewViewModel
-    private lateinit var httpClient: HttpClient
 
     private val requestPermission = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -65,29 +52,6 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         cameraAdapter = CameraXAdapter(this)
-
-        httpClient = HttpClient(OkHttp) {
-            install(ContentNegotiation) {
-                json(Json { ignoreUnknownKeys = true })
-            }
-        }
-
-        val processImageUseCase = ProcessCapturedImageUseCase(
-            imagePreprocessor = OcrBasedSpineDetector(this),
-            ocrEngine = MlKitOcrAdapter(this),
-            metadataLookupService = OpenLibraryMetadataLookupService(httpClient),
-            scanRepository = DefaultScanRepository()
-        )
-
-        scanViewModel = ScanViewModel(
-            processImage = processImageUseCase,
-            scope = lifecycleScope
-        )
-
-        reviewViewModel = ReviewViewModel(
-            collectionRepository = DefaultCollectionRepository(),
-            scope = lifecycleScope
-        )
 
         mainViewModel.cameraPermissionGranted = ContextCompat.checkSelfPermission(
             this, Manifest.permission.CAMERA
@@ -103,16 +67,11 @@ class MainActivity : ComponentActivity() {
                     cameraPermissionGranted = mainViewModel.cameraPermissionGranted,
                     onRequestPermission = { requestPermission.launch(Manifest.permission.CAMERA) },
                     cameraAdapter = cameraAdapter,
-                    scanViewModel = scanViewModel,
-                    reviewViewModel = reviewViewModel
+                    scanViewModel = androidScanViewModel.shared,
+                    reviewViewModel = androidReviewViewModel.shared
                 )
             }
         }
-    }
-
-    override fun onDestroy() {
-        if (::httpClient.isInitialized) httpClient.close()
-        super.onDestroy()
     }
 }
 
@@ -126,7 +85,7 @@ fun ShelfScanApp(
     scanViewModel: ScanViewModel,
     reviewViewModel: ReviewViewModel
 ) {
-    var currentScreen by remember { mutableStateOf(Screen.HOME) }
+    var currentScreen by rememberSaveable { mutableStateOf(Screen.HOME) }
     val scanState by scanViewModel.state.collectAsState()
     val reviewState by reviewViewModel.state.collectAsState()
 

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/MainActivity.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/MainActivity.kt
@@ -198,17 +198,26 @@ fun ScanScreen(
                 }
             }
             else -> {
+                // Local in-flight flag avoids the race window between tap and
+                // ScanState.isLoading flipping. Without it, fast double-taps
+                // launch concurrent cameraAdapter.captureImage() calls.
+                var isCapturing by remember { mutableStateOf(false) }
                 Button(
                     onClick = {
+                        if (isCapturing) return@Button
+                        isCapturing = true
                         coroutineScope.launch {
                             try {
                                 val image = cameraAdapter.captureImage()
                                 scanViewModel.onAction(ScanAction.CaptureImage(image))
                             } catch (_: Exception) {
                                 scanViewModel.onAction(ScanAction.RetryCapture)
+                            } finally {
+                                isCapturing = false
                             }
                         }
                     },
+                    enabled = !isCapturing,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(24.dp)

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/MainActivity.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/MainActivity.kt
@@ -23,6 +23,7 @@ import com.shelfscan.android.camera.CameraXAdapter
 import com.shelfscan.android.ui.ReviewScreen
 import com.shelfscan.android.viewmodel.AndroidReviewViewModel
 import com.shelfscan.android.viewmodel.AndroidScanViewModel
+import com.shelfscan.shared.core.model.ScanError
 import com.shelfscan.shared.core.model.ScanStatus
 import com.shelfscan.shared.feature.review.ReviewAction
 import com.shelfscan.shared.feature.review.ReviewViewModel
@@ -187,7 +188,7 @@ fun ScanScreen(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Text(
-                        "Scan failed. Please try again.",
+                        scanFailureMessage(scanState.error),
                         color = MaterialTheme.colorScheme.error
                     )
                     Spacer(modifier = Modifier.height(8.dp))
@@ -217,6 +218,17 @@ fun ScanScreen(
             }
         }
     }
+}
+
+private fun scanFailureMessage(error: ScanError?): String = when (error) {
+    ScanError.OcrFailed -> "Couldn't read text on the spines. Try again with brighter, steadier light."
+    ScanError.MetadataLookupFailed -> "Couldn't reach the catalogue. Check your connection and retry."
+    ScanError.SaveFailed -> "Couldn't save the scan. Please try again."
+    ScanError.ImageProcessingFailed -> "Couldn't process the photo. Please retake it."
+    ScanError.CameraUnavailable -> "The camera is unavailable on this device."
+    ScanError.PermissionDenied -> "Camera permission is required to scan a shelf."
+    ScanError.ImageTooBlurry -> "The photo was too blurry. Please retake it."
+    null -> "Scan failed. Please try again."
 }
 
 @Composable

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ShelfScanApplication.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ShelfScanApplication.kt
@@ -1,0 +1,54 @@
+package com.shelfscan.android
+
+import android.app.Application
+import com.shelfscan.android.image.OcrBasedSpineDetector
+import com.shelfscan.android.ocr.MlKitOcrAdapter
+import com.shelfscan.shared.data.metadata.OpenLibraryMetadataLookupService
+import com.shelfscan.shared.data.repository.DefaultCollectionRepository
+import com.shelfscan.shared.data.repository.DefaultScanRepository
+import com.shelfscan.shared.domain.scan.ProcessCapturedImageUseCase
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+/**
+ * Process-scoped owner of singletons that must outlive Activity recreation:
+ * the HTTP client, the in-memory repositories, and the ML Kit-backed adapters.
+ *
+ * Construction is idempotent across configuration changes — `onCreate` here
+ * is called exactly once per process, regardless of how often the user
+ * rotates the screen.
+ *
+ * Resource lifecycle (HttpClient close, ML Kit recogniser close, repository
+ * thread-safety) is tracked separately in #19.
+ */
+class ShelfScanApplication : Application() {
+
+    private lateinit var httpClient: HttpClient
+
+    lateinit var scanRepository: DefaultScanRepository
+        private set
+    lateinit var collectionRepository: DefaultCollectionRepository
+        private set
+    lateinit var processCapturedImageUseCase: ProcessCapturedImageUseCase
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        httpClient = HttpClient(OkHttp) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+        scanRepository = DefaultScanRepository()
+        collectionRepository = DefaultCollectionRepository()
+        processCapturedImageUseCase = ProcessCapturedImageUseCase(
+            imagePreprocessor = OcrBasedSpineDetector(this),
+            ocrEngine = MlKitOcrAdapter(this),
+            metadataLookupService = OpenLibraryMetadataLookupService(httpClient),
+            scanRepository = scanRepository,
+        )
+    }
+}

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ShelfScanApplication.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ShelfScanApplication.kt
@@ -1,6 +1,9 @@
 package com.shelfscan.android
 
 import android.app.Application
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.shelfscan.android.image.OcrBasedSpineDetector
 import com.shelfscan.android.ocr.MlKitOcrAdapter
 import com.shelfscan.shared.data.metadata.OpenLibraryMetadataLookupService
@@ -9,6 +12,7 @@ import com.shelfscan.shared.data.repository.DefaultScanRepository
 import com.shelfscan.shared.domain.scan.ProcessCapturedImageUseCase
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -27,6 +31,7 @@ import kotlinx.serialization.json.Json
 class ShelfScanApplication : Application() {
 
     private lateinit var httpClient: HttpClient
+    private lateinit var textRecognizer: TextRecognizer
 
     lateinit var scanRepository: DefaultScanRepository
         private set
@@ -41,14 +46,33 @@ class ShelfScanApplication : Application() {
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
             }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 5_000
+                connectTimeoutMillis = 5_000
+            }
         }
+        // One ML Kit recogniser shared by both the OCR adapter and the
+        // OCR-based segmenter. Loading the latin model is expensive — doing it
+        // twice per Activity recreation was the previous default.
+        textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+
         scanRepository = DefaultScanRepository()
         collectionRepository = DefaultCollectionRepository()
         processCapturedImageUseCase = ProcessCapturedImageUseCase(
-            imagePreprocessor = OcrBasedSpineDetector(this),
-            ocrEngine = MlKitOcrAdapter(this),
+            imagePreprocessor = OcrBasedSpineDetector(this, textRecognizer),
+            ocrEngine = MlKitOcrAdapter(this, textRecognizer),
             metadataLookupService = OpenLibraryMetadataLookupService(httpClient),
             scanRepository = scanRepository,
         )
+    }
+
+    override fun onTerminate() {
+        // Best-effort cleanup. Android docs note onTerminate is not guaranteed
+        // to fire in production — a full process-shutdown leak protection
+        // would need a different mechanism. Either way, we no longer leak
+        // these per Activity recreation, which was the actual bug.
+        if (::httpClient.isInitialized) httpClient.close()
+        if (::textRecognizer.isInitialized) textRecognizer.close()
+        super.onTerminate()
     }
 }

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/image/BitmapCropper.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/image/BitmapCropper.kt
@@ -2,31 +2,55 @@ package com.shelfscan.android.image
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.BitmapRegionDecoder
+import android.graphics.Rect
+import com.shelfscan.shared.core.geometry.clampToImage
 import com.shelfscan.shared.core.model.BoundingBox
 import java.io.File
 import java.io.FileOutputStream
 
+/**
+ * Crops a region of an on-disk image and writes it back as a JPEG.
+ *
+ * Uses `BitmapRegionDecoder` so only the requested rectangle is materialised
+ * in memory — a 4000×3000 source image cropped to a 200×3000 spine costs
+ * ~2.4 MB rather than the ~48 MB that a full `decodeFile` would.
+ */
 class BitmapCropper(private val cacheDir: File) {
 
     fun cropAndSave(sourceRef: String, box: BoundingBox, id: String): String {
-        val bitmap = BitmapFactory.decodeFile(sourceRef)
-            ?: throw IllegalArgumentException("Cannot decode image: $sourceRef")
+        val (sourceWidth, sourceHeight) = readImageSize(sourceRef)
 
-        val left = box.left.toInt().coerceIn(0, bitmap.width - 1)
-        val top = box.top.toInt().coerceIn(0, bitmap.height - 1)
-        val right = box.right.toInt().coerceIn(left + 1, bitmap.width)
-        val bottom = box.bottom.toInt().coerceIn(top + 1, bitmap.height)
+        val rect = box.clampToImage(sourceWidth, sourceHeight)
+        val regionRect = Rect(rect.left, rect.top, rect.right, rect.bottom)
 
-        val cropped = Bitmap.createBitmap(bitmap, left, top, right - left, bottom - top)
+        val cropped = decodeRegion(sourceRef, regionRect)
+            ?: throw IllegalArgumentException("Cannot decode region of image: $sourceRef")
+
         val outputFile = File(cacheDir, "spine_${id}_${System.currentTimeMillis()}.jpg")
-
         FileOutputStream(outputFile).use { out ->
             cropped.compress(Bitmap.CompressFormat.JPEG, 90, out)
         }
-
-        if (cropped !== bitmap) cropped.recycle()
-        bitmap.recycle()
+        cropped.recycle()
 
         return outputFile.absolutePath
+    }
+
+    private fun readImageSize(sourceRef: String): Pair<Int, Int> {
+        val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(sourceRef, opts)
+        if (opts.outWidth <= 0 || opts.outHeight <= 0) {
+            throw IllegalArgumentException("Cannot read dimensions of image: $sourceRef")
+        }
+        return opts.outWidth to opts.outHeight
+    }
+
+    private fun decodeRegion(sourceRef: String, region: Rect): Bitmap? {
+        val decoder = BitmapRegionDecoder.newInstance(sourceRef, false)
+        return try {
+            decoder.decodeRegion(region, BitmapFactory.Options())
+        } finally {
+            decoder.recycle()
+        }
     }
 }

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/image/OcrBasedSpineDetector.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/image/OcrBasedSpineDetector.kt
@@ -4,8 +4,7 @@ import android.content.Context
 import android.graphics.BitmapFactory
 import android.net.Uri
 import com.google.mlkit.vision.common.InputImage
-import com.google.mlkit.vision.text.TextRecognition
-import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.google.mlkit.vision.text.TextRecognizer
 import com.shelfscan.android.ocr.toRecognizedTextBlocks
 import com.shelfscan.shared.core.model.BoundingBox
 import com.shelfscan.shared.core.model.CapturedImage
@@ -20,11 +19,10 @@ import kotlin.coroutines.resume
 
 class OcrBasedSpineDetector(
     private val context: Context,
+    private val recogniser: TextRecognizer,
     private val clusterAlgorithm: SpineClusteringAlgorithm = SpineClusteringAlgorithm(),
     private val bitmapCropper: BitmapCropper = BitmapCropper(context.cacheDir)
 ) : ImagePreprocessor {
-
-    private val recogniser = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
 
     override suspend fun normalizeForOcr(image: CapturedImage): ProcessedImage {
         return ProcessedImage(

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/image/OcrBasedSpineDetector.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/image/OcrBasedSpineDetector.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.shelfscan.android.ocr.toRecognizedTextBlocks
 import com.shelfscan.shared.core.model.BoundingBox
 import com.shelfscan.shared.core.model.CapturedImage
 import com.shelfscan.shared.core.model.DetectedSpine
@@ -16,7 +17,6 @@ import com.shelfscan.shared.platform.ImagePreprocessor
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.File
 import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 class OcrBasedSpineDetector(
     private val context: Context,
@@ -77,24 +77,7 @@ class OcrBasedSpineDetector(
 
             recogniser.process(inputImage)
                 .addOnSuccessListener { result ->
-                    val blocks = result.textBlocks.flatMap { block ->
-                        block.lines.map { line ->
-                            val bbox = line.boundingBox
-                            RecognizedTextBlock(
-                                text = line.text,
-                                confidence = line.confidence,
-                                boundingBox = bbox?.let {
-                                    BoundingBox(
-                                        left = it.left.toFloat(),
-                                        top = it.top.toFloat(),
-                                        right = it.right.toFloat(),
-                                        bottom = it.bottom.toFloat()
-                                    )
-                                }
-                            )
-                        }
-                    }
-                    continuation.resume(blocks)
+                    continuation.resume(result.toRecognizedTextBlocks())
                 }
                 .addOnFailureListener {
                     continuation.resume(emptyList())

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ocr/MlKitOcrAdapter.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ocr/MlKitOcrAdapter.kt
@@ -3,8 +3,7 @@ package com.shelfscan.android.ocr
 import android.content.Context
 import android.net.Uri
 import com.google.mlkit.vision.common.InputImage
-import com.google.mlkit.vision.text.TextRecognition
-import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.google.mlkit.vision.text.TextRecognizer
 import com.shelfscan.shared.core.model.OcrResult
 import com.shelfscan.shared.core.model.ProcessedImage
 import com.shelfscan.shared.platform.OcrEngine
@@ -13,8 +12,15 @@ import java.io.File
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-class MlKitOcrAdapter(private val context: Context) : OcrEngine {
-    private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+/**
+ * Adapter from the shared `OcrEngine` contract to ML Kit's `TextRecognizer`.
+ * The recognizer is constructed once in `ShelfScanApplication` and shared
+ * with `OcrBasedSpineDetector` to avoid loading the model twice.
+ */
+class MlKitOcrAdapter(
+    private val context: Context,
+    private val recognizer: TextRecognizer,
+) : OcrEngine {
 
     override suspend fun recognizeText(image: ProcessedImage): OcrResult =
         suspendCancellableCoroutine { continuation ->

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ocr/MlKitOcrAdapter.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ocr/MlKitOcrAdapter.kt
@@ -5,10 +5,8 @@ import android.net.Uri
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
-import com.shelfscan.shared.core.model.BoundingBox
 import com.shelfscan.shared.core.model.OcrResult
 import com.shelfscan.shared.core.model.ProcessedImage
-import com.shelfscan.shared.core.model.RecognizedTextBlock
 import com.shelfscan.shared.platform.OcrEngine
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.File
@@ -33,24 +31,9 @@ class MlKitOcrAdapter(private val context: Context) : OcrEngine {
             }
             recognizer.process(inputImage)
                 .addOnSuccessListener { result ->
-                    val blocks = result.textBlocks.flatMap { block ->
-                        block.lines.map { line ->
-                            val bbox = line.boundingBox
-                            RecognizedTextBlock(
-                                text = line.text,
-                                confidence = line.confidence ?: 0.7f,
-                                boundingBox = bbox?.let {
-                                    BoundingBox(
-                                        left = it.left.toFloat(),
-                                        top = it.top.toFloat(),
-                                        right = it.right.toFloat(),
-                                        bottom = it.bottom.toFloat()
-                                    )
-                                }
-                            )
-                        }
-                    }
-                    continuation.resume(OcrResult(blocks = blocks, rawText = result.text))
+                    continuation.resume(
+                        OcrResult(blocks = result.toRecognizedTextBlocks(), rawText = result.text)
+                    )
                 }
                 .addOnFailureListener { exception ->
                     continuation.resumeWithException(exception)

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ocr/MlKitTextMappers.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ocr/MlKitTextMappers.kt
@@ -1,0 +1,23 @@
+package com.shelfscan.android.ocr
+
+import com.google.mlkit.vision.text.Text
+import com.shelfscan.shared.core.model.BoundingBox
+import com.shelfscan.shared.core.model.RecognizedTextBlock
+
+internal fun Text.toRecognizedTextBlocks(): List<RecognizedTextBlock> =
+    textBlocks.flatMap { block ->
+        block.lines.map { line ->
+            RecognizedTextBlock(
+                text = line.text,
+                confidence = line.confidence,
+                boundingBox = line.boundingBox?.let {
+                    BoundingBox(
+                        left = it.left.toFloat(),
+                        top = it.top.toFloat(),
+                        right = it.right.toFloat(),
+                        bottom = it.bottom.toFloat(),
+                    )
+                },
+            )
+        }
+    }

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ui/ReviewScreen.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ui/ReviewScreen.kt
@@ -18,6 +18,7 @@ import com.shelfscan.shared.core.model.ConfidenceBand
 import com.shelfscan.shared.core.model.ItemSource
 import com.shelfscan.shared.core.model.MediaItem
 import com.shelfscan.shared.core.model.MediaType
+import com.shelfscan.shared.core.model.ScanError
 import com.shelfscan.shared.feature.review.ReviewAction
 import com.shelfscan.shared.feature.review.ReviewState
 import com.shelfscan.shared.feature.review.ReviewViewModel
@@ -157,48 +158,107 @@ fun ReviewScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        if (reviewState.savedToCollection) {
-            Text("Saved!", style = MaterialTheme.typography.bodyLarge)
-            Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = onDone, modifier = Modifier.fillMaxWidth()) {
-                Text("Back to Home")
+        reviewState.error?.let { error ->
+            Text(
+                text = reviewErrorMessage(error),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+
+        when {
+            reviewState.savedToCollection -> {
+                Text("Saved!", style = MaterialTheme.typography.bodyLarge)
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = onDone, modifier = Modifier.fillMaxWidth()) {
+                    Text("Back to Home")
+                }
             }
-        } else {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Button(
-                    onClick = {
-                        reviewViewModel.onAction(
-                            ReviewAction.SaveToCollection(
-                                collectionId = "default",
-                                collectionName = "My Books"
+            reviewState.isLoading -> {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text("Saving…")
+                }
+            }
+            else -> {
+                var showDiscardConfirm by remember { mutableStateOf(false) }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Button(
+                        onClick = {
+                            reviewViewModel.onAction(
+                                ReviewAction.SaveToCollection(
+                                    collectionId = "default",
+                                    collectionName = "My Books"
+                                )
                             )
-                        )
-                    },
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text("Save")
+                        },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("Save")
+                    }
+                    FilledTonalButton(
+                        onClick = { reviewViewModel.onAction(ReviewAction.ApproveAll) },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("Approve All")
+                    }
+                    OutlinedButton(
+                        onClick = { showDiscardConfirm = true },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("Discard")
+                    }
                 }
-                FilledTonalButton(
-                    onClick = { reviewViewModel.onAction(ReviewAction.ApproveAll) },
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text("Approve All")
-                }
-                OutlinedButton(
-                    onClick = {
-                        reviewViewModel.onAction(ReviewAction.DiscardAll)
-                        onDone()
-                    },
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text("Discard")
+
+                if (showDiscardConfirm) {
+                    AlertDialog(
+                        onDismissRequest = { showDiscardConfirm = false },
+                        title = { Text("Discard scan?") },
+                        text = {
+                            Text(
+                                "This removes all ${reviewState.items.size} detected " +
+                                    "items. You can't undo this."
+                            )
+                        },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                showDiscardConfirm = false
+                                reviewViewModel.onAction(ReviewAction.DiscardAll)
+                                onDone()
+                            }) {
+                                Text("Discard", color = MaterialTheme.colorScheme.error)
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showDiscardConfirm = false }) {
+                                Text("Cancel")
+                            }
+                        }
+                    )
                 }
             }
         }
     }
+}
+
+private fun reviewErrorMessage(error: ScanError): String = when (error) {
+    ScanError.SaveFailed -> "Couldn't save the collection. Please try again."
+    ScanError.MetadataLookupFailed -> "Couldn't look up book details right now."
+    ScanError.OcrFailed -> "Couldn't read text on the spines."
+    ScanError.ImageProcessingFailed -> "Couldn't process the photo."
+    ScanError.CameraUnavailable -> "Camera unavailable."
+    ScanError.PermissionDenied -> "Camera permission required."
+    ScanError.ImageTooBlurry -> "Photo was too blurry."
 }
 
 @Composable

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/viewmodel/AndroidReviewViewModel.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/viewmodel/AndroidReviewViewModel.kt
@@ -1,0 +1,20 @@
+package com.shelfscan.android.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.shelfscan.android.ShelfScanApplication
+import com.shelfscan.shared.feature.review.ReviewViewModel
+
+/**
+ * AndroidX wrapper around the shared `ReviewViewModel`. See
+ * [AndroidScanViewModel] for rationale.
+ */
+class AndroidReviewViewModel(application: Application) : AndroidViewModel(application) {
+    private val app = application as ShelfScanApplication
+
+    val shared: ReviewViewModel = ReviewViewModel(
+        collectionRepository = app.collectionRepository,
+        scope = viewModelScope,
+    )
+}

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/viewmodel/AndroidScanViewModel.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/viewmodel/AndroidScanViewModel.kt
@@ -1,0 +1,25 @@
+package com.shelfscan.android.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.shelfscan.android.ShelfScanApplication
+import com.shelfscan.shared.feature.scan.ScanViewModel
+
+/**
+ * AndroidX wrapper around the shared `ScanViewModel`.
+ *
+ * Constructing the wrapper via `by viewModels()` ties its lifetime to the
+ * `ViewModelStore` rather than the Activity instance, so scan progress and
+ * the resulting session survive rotation. Coroutines launched inside
+ * `ScanViewModel` are bound to `viewModelScope` and cancelled when the user
+ * actually navigates away, not when the Activity is merely recreated.
+ */
+class AndroidScanViewModel(application: Application) : AndroidViewModel(application) {
+    private val app = application as ShelfScanApplication
+
+    val shared: ScanViewModel = ScanViewModel(
+        processImage = app.processCapturedImageUseCase,
+        scope = viewModelScope,
+    )
+}

--- a/shelfscan/androidApp/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/shelfscan/androidApp/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <!-- Stylised stack of three books on a shelf, drawn within the safe area
+         (centred 72×72 box at offset 18,18). -->
+    <group android:translateX="20" android:translateY="22">
+        <!-- Tall book -->
+        <path android:fillColor="#FFFFFF" android:pathData="M6,10 h12 v54 h-12 z" />
+        <!-- Medium book, slightly tilted right via gradient stroke -->
+        <path android:fillColor="#FFFFFF" android:pathData="M22,16 h12 v48 h-12 z" />
+        <!-- Short fat book -->
+        <path android:fillColor="#FFFFFF" android:pathData="M38,24 h22 v40 h-22 z" />
+        <!-- Shelf line -->
+        <path android:fillColor="#FFFFFF" android:pathData="M2,64 h62 v3 h-62 z" />
+    </group>
+</vector>

--- a/shelfscan/androidApp/src/main/res/layout/activity_main.xml
+++ b/shelfscan/androidApp/src/main/res/layout/activity_main.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent" />

--- a/shelfscan/androidApp/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/shelfscan/androidApp/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/shelfscan/androidApp/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/shelfscan/androidApp/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/shelfscan/androidApp/src/main/res/values/colors.xml
+++ b/shelfscan/androidApp/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#1976D2</color>
+</resources>

--- a/shelfscan/androidApp/src/main/res/values/themes.xml
+++ b/shelfscan/androidApp/src/main/res/values/themes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+      Activity-side theme is intentionally minimal: Compose draws the rest of
+      the UI. This theme exists only to give the activity a sane no-action-bar
+      base before setContent { } takes over, and to drop the AppCompat
+      dependency that the previous Theme.AppCompat.DayNight.NoActionBar
+      pulled in.
+    -->
+    <style name="Theme.ShelfScan" parent="android:Theme.Material.Light.NoActionBar" />
+</resources>

--- a/shelfscan/gradle/libs.versions.toml
+++ b/shelfscan/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ androidxTestRunner = "1.6.2"
 androidxTestRules = "1.6.1"
 androidxTestExtJunit = "1.2.1"
 activityCompose = "1.13.0"
-appcompat = "1.7.1"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -53,7 +52,6 @@ compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 
 # Test
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/core/geometry/BoundingBoxClamping.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/core/geometry/BoundingBoxClamping.kt
@@ -1,0 +1,22 @@
+package com.shelfscan.shared.core.geometry
+
+import com.shelfscan.shared.core.model.BoundingBox
+
+/**
+ * Integer rectangle clamped into a `[0, width) × [0, height)` image, with at
+ * least one pixel on each side. Returned as four ints rather than a domain
+ * type to keep the platform crop call sites trivial.
+ */
+data class ClampedRect(val left: Int, val top: Int, val right: Int, val bottom: Int) {
+    val width: Int get() = right - left
+    val height: Int get() = bottom - top
+}
+
+fun BoundingBox.clampToImage(imageWidth: Int, imageHeight: Int): ClampedRect {
+    require(imageWidth > 0 && imageHeight > 0) { "Image dimensions must be positive" }
+    val left = left.toInt().coerceIn(0, imageWidth - 1)
+    val top = top.toInt().coerceIn(0, imageHeight - 1)
+    val right = right.toInt().coerceIn(left + 1, imageWidth)
+    val bottom = bottom.toInt().coerceIn(top + 1, imageHeight)
+    return ClampedRect(left, top, right, bottom)
+}

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/core/model/Models.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/core/model/Models.kt
@@ -105,6 +105,7 @@ sealed interface ScanError {
     data object CameraUnavailable : ScanError
     data object PermissionDenied : ScanError
     data object ImageTooBlurry : ScanError
+    data object ImageProcessingFailed : ScanError
     data object OcrFailed : ScanError
     data object MetadataLookupFailed : ScanError
     data object SaveFailed : ScanError

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/metadata/OpenLibraryMetadataLookupService.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/metadata/OpenLibraryMetadataLookupService.kt
@@ -7,15 +7,28 @@ import com.shelfscan.shared.platform.MetadataLookupService
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Looks up books in the Open Library API.
+ *
+ * Request timeouts are the responsibility of the supplied `client` — install
+ * the `HttpTimeout` plugin with sane bounds at construction time, e.g.
+ * `install(HttpTimeout) { requestTimeoutMillis = 5_000 }`. We can't enforce a
+ * timeout from inside this class portably (kotlinx.coroutines.withTimeout
+ * misbehaves under runTest's virtual time, and Ktor's per-request timeout DSL
+ * needs the plugin installed regardless).
+ */
 class OpenLibraryMetadataLookupService(
     private val client: HttpClient,
     private val baseUrl: String = "https://openlibrary.org",
     private val resultLimit: Int = 5,
+    private val userAgent: String = DEFAULT_USER_AGENT,
 ) : MetadataLookupService {
 
     override suspend fun search(
@@ -30,11 +43,13 @@ class OpenLibraryMetadataLookupService(
 
         val response: HttpResponse = try {
             client.get("$baseUrl/search.json") {
+                header(HttpHeaders.UserAgent, userAgent)
                 if (titleQ.isNotEmpty()) url.parameters.append("title", titleQ)
                 if (creatorQ.isNotEmpty()) url.parameters.append("author", creatorQ)
                 url.parameters.append("limit", resultLimit.toString())
             }
         } catch (e: Throwable) {
+            // Network failure, timeout, host unreachable — degrade gracefully.
             return emptyList()
         }
 
@@ -46,21 +61,58 @@ class OpenLibraryMetadataLookupService(
             return emptyList()
         }
 
-        return payload.docs.mapIndexed { index, doc ->
+        return payload.docs.map { doc ->
             CatalogMatch(
                 source = CatalogSource(SOURCE_NAME),
                 mediaType = MediaType.BOOK,
                 title = doc.title.orEmpty(),
                 creatorName = doc.authorName?.firstOrNull(),
                 year = doc.firstPublishYear,
-                score = (1.0 - index * 0.1).coerceAtLeast(0.0),
+                score = scoreMatch(
+                    queryTitle = titleQ,
+                    queryAuthor = creatorQ,
+                    docTitle = doc.title.orEmpty(),
+                    docAuthor = doc.authorName?.firstOrNull().orEmpty(),
+                ),
                 externalId = doc.key.orEmpty(),
             )
         }
     }
 
+    /**
+     * Score a candidate by token-Jaccard similarity against the query.
+     * Title carries 70% of the weight, author 30% — and only if the user
+     * supplied an author query, otherwise we score on title alone.
+     */
+    private fun scoreMatch(
+        queryTitle: String,
+        queryAuthor: String,
+        docTitle: String,
+        docAuthor: String,
+    ): Double {
+        val titleSim = jaccard(tokenize(queryTitle), tokenize(docTitle))
+        if (queryAuthor.isBlank()) return titleSim
+        val authorSim = jaccard(tokenize(queryAuthor), tokenize(docAuthor))
+        return TITLE_WEIGHT * titleSim + AUTHOR_WEIGHT * authorSim
+    }
+
+    private fun tokenize(text: String): Set<String> =
+        text.lowercase().split(TOKEN_SEPARATOR).filter { it.isNotBlank() }.toSet()
+
+    private fun jaccard(a: Set<String>, b: Set<String>): Double {
+        if (a.isEmpty() || b.isEmpty()) return 0.0
+        val intersection = a.intersect(b).size
+        val union = a.union(b).size
+        return intersection.toDouble() / union.toDouble()
+    }
+
     companion object {
         const val SOURCE_NAME = "OpenLibrary"
+        const val DEFAULT_USER_AGENT = "ShelfScan/1.0 (https://github.com/bovinemagnet/BookShelfScanner)"
+
+        private const val TITLE_WEIGHT = 0.7
+        private const val AUTHOR_WEIGHT = 0.3
+        private val TOKEN_SEPARATOR = Regex("[\\s\\p{Punct}]+")
     }
 }
 

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/repository/DefaultCollectionRepository.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/repository/DefaultCollectionRepository.kt
@@ -2,23 +2,36 @@ package com.shelfscan.shared.data.repository
 
 import com.shelfscan.shared.core.model.Collection
 import com.shelfscan.shared.core.model.MediaItem
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
+/**
+ * In-memory `CollectionRepository`. Reads and writes are serialised through a
+ * `Mutex` so concurrent saves from review coroutines can't race on the
+ * underlying map.
+ */
 class DefaultCollectionRepository : CollectionRepository {
+    private val mutex = Mutex()
     private val collections = mutableMapOf<String, Collection>()
 
-    override suspend fun saveCollection(collection: Collection) {
+    override suspend fun saveCollection(collection: Collection) = mutex.withLock {
         collections[collection.id] = collection
     }
 
-    override suspend fun getCollection(id: String): Collection? = collections[id]
-
-    override suspend fun saveItems(collectionId: String, items: List<MediaItem>) {
-        val collection = collections[collectionId] ?: return
-        collections[collectionId] = collection.copy(items = items)
+    override suspend fun getCollection(id: String): Collection? = mutex.withLock {
+        collections[id]
     }
 
-    override suspend fun getCollectionItems(collectionId: String): List<MediaItem> =
-        collections[collectionId]?.items ?: emptyList()
+    override suspend fun saveItems(collectionId: String, items: List<MediaItem>) = mutex.withLock {
+        val existing = collections[collectionId] ?: return@withLock
+        collections[collectionId] = existing.copy(items = items)
+    }
 
-    override suspend fun getAllCollections(): List<Collection> = collections.values.toList()
+    override suspend fun getCollectionItems(collectionId: String): List<MediaItem> = mutex.withLock {
+        collections[collectionId]?.items ?: emptyList()
+    }
+
+    override suspend fun getAllCollections(): List<Collection> = mutex.withLock {
+        collections.values.toList()
+    }
 }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/repository/DefaultScanRepository.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/repository/DefaultScanRepository.kt
@@ -1,15 +1,27 @@
 package com.shelfscan.shared.data.repository
 
 import com.shelfscan.shared.core.model.ScanSession
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
+/**
+ * In-memory `ScanRepository`. Reads and writes are serialised through a
+ * `Mutex` so concurrent calls from camera, OCR, and review coroutines can't
+ * race on the underlying map.
+ */
 class DefaultScanRepository : ScanRepository {
+    private val mutex = Mutex()
     private val sessions = mutableMapOf<String, ScanSession>()
 
-    override suspend fun saveSession(session: ScanSession) {
+    override suspend fun saveSession(session: ScanSession) = mutex.withLock {
         sessions[session.id] = session
     }
 
-    override suspend fun getSession(id: String): ScanSession? = sessions[id]
+    override suspend fun getSession(id: String): ScanSession? = mutex.withLock {
+        sessions[id]
+    }
 
-    override suspend fun getAllSessions(): List<ScanSession> = sessions.values.toList()
+    override suspend fun getAllSessions(): List<ScanSession> = mutex.withLock {
+        sessions.values.toList()
+    }
 }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/export/ExportCollectionUseCase.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/export/ExportCollectionUseCase.kt
@@ -1,6 +1,9 @@
 package com.shelfscan.shared.domain.export
 
 import com.shelfscan.shared.core.model.MediaItem
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
 
 class ExportCollectionUseCase {
     enum class ExportFormat { CSV, JSON }
@@ -28,12 +31,17 @@ class ExportCollectionUseCase {
         return (listOf(header) + rows).joinToString("\n")
     }
 
-    private fun toJson(items: List<MediaItem>): String {
-        val entries = items.joinToString(",\n  ") { item ->
-            """{"id":"${item.id}","mediaType":"${item.mediaType}","title":${item.title?.let { "\"${it.escapeJson()}\"" } ?: "null"},"creatorName":${item.creatorName?.let { "\"${it.escapeJson()}\"" } ?: "null"},"confidence":${item.confidence.value},"source":"${item.source}"}"""
-        }
-        return "[\n  $entries\n]"
-    }
+    private fun toJson(items: List<MediaItem>): String =
+        json.encodeToString(ListSerializer(MediaItemDto.serializer()), items.map { it.toDto() })
+
+    private fun MediaItem.toDto() = MediaItemDto(
+        id = id,
+        mediaType = mediaType.name,
+        title = title,
+        creatorName = creatorName,
+        confidence = confidence.value,
+        source = source.name,
+    )
 
     private fun String.escapeCsv(): String {
         return if (contains(',') || contains('"') || contains('\n')) {
@@ -41,6 +49,20 @@ class ExportCollectionUseCase {
         } else this
     }
 
-    private fun String.escapeJson(): String =
-        replace("\\", "\\\\").replace("\"", "\\\"")
+    private companion object {
+        // prettyPrint matches the previous output style closely while letting
+        // kotlinx-serialization handle all RFC-8259 escaping correctly.
+        val json = Json { prettyPrint = true; encodeDefaults = false }
+    }
+
+    /** Stable wire format for exported items — decoupled from the rich domain model. */
+    @Serializable
+    private data class MediaItemDto(
+        val id: String,
+        val mediaType: String,
+        val title: String?,
+        val creatorName: String?,
+        val confidence: Double,
+        val source: String,
+    )
 }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ParseDetectedItemUseCase.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ParseDetectedItemUseCase.kt
@@ -2,23 +2,78 @@ package com.shelfscan.shared.domain.scan
 
 import com.shelfscan.shared.core.model.RecognizedTextBlock
 
+/**
+ * Picks the most likely title and author/creator from a per-spine OCR result.
+ *
+ * Heuristics, in order of strength:
+ *  1. **Bounding-box height** — when boxes are available, the line set in the
+ *     largest font is almost always the title.
+ *  2. **Initial pattern (`R.`, `J. K.`)** — a line containing an initial is
+ *     overwhelmingly an author byline. The longest *other* line is the title.
+ *  3. **Longest non-author line** — fallback when no font-size or initial cues
+ *     are present.
+ *
+ * `confidence` reflects which heuristic fired, so downstream scoring can
+ * weight it instead of treating every parse identically.
+ */
 class ParseDetectedItemUseCase {
     data class ParsedItem(
         val titleCandidate: String?,
         val creatorCandidate: String?,
-        val allLines: List<String>
+        val allLines: List<String>,
+        val confidence: Double
     )
 
     fun execute(blocks: List<RecognizedTextBlock>): ParsedItem {
-        val lines = blocks.map { it.text.trim() }.filter { it.isNotBlank() }
-        if (lines.isEmpty()) return ParsedItem(null, null, emptyList())
+        val candidates = blocks.filter { it.text.trim().isNotBlank() }
+        val lines = candidates.map { it.text.trim() }
+        if (candidates.isEmpty()) {
+            return ParsedItem(null, null, emptyList(), confidence = 0.1)
+        }
 
-        val titleCandidate = lines.maxByOrNull { it.length }
-        val creatorCandidate = lines
+        val authorBlock = candidates.firstOrNull { containsInitial(it.text.trim()) }
+        val authorCandidate = authorBlock?.text?.trim()
+
+        val titlePool = candidates.filter { it !== authorBlock }.ifEmpty { candidates }
+
+        val hasBoxes = titlePool.any { it.boundingBox != null }
+        val titleBlock = if (hasBoxes) {
+            titlePool.maxByOrNull { it.boundingBox?.let { b -> b.bottom - b.top } ?: 0f }
+        } else {
+            titlePool.maxByOrNull { it.text.trim().length }
+        }
+        val titleCandidate = titleBlock?.text?.trim()
+
+        val creatorCandidate = authorCandidate ?: lines
             .filter { it != titleCandidate }
             .firstOrNull { line ->
                 line.contains(' ') && !line.all { c -> c.isUpperCase() || !c.isLetter() }
             }
-        return ParsedItem(titleCandidate, creatorCandidate, lines)
+
+        val confidence = computeConfidence(
+            hasBoxes = hasBoxes,
+            usedInitial = authorBlock != null,
+            titleFound = titleCandidate != null
+        )
+
+        return ParsedItem(titleCandidate, creatorCandidate, lines, confidence)
+    }
+
+    private fun containsInitial(text: String): Boolean =
+        INITIAL_PATTERN.containsMatchIn(text)
+
+    private fun computeConfidence(hasBoxes: Boolean, usedInitial: Boolean, titleFound: Boolean): Double =
+        when {
+            !titleFound -> 0.1
+            hasBoxes && usedInitial -> 0.85
+            hasBoxes -> 0.75
+            usedInitial -> 0.7
+            else -> 0.55
+        }
+
+    private companion object {
+        // A standalone capital letter immediately followed by a dot — "R.", "C." —
+        // is a strong byline signal that almost never appears in real book titles.
+        val INITIAL_PATTERN = Regex("(?:^|\\s)[A-Z]\\.")
     }
 }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ProcessCapturedImageUseCase.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ProcessCapturedImageUseCase.kt
@@ -20,10 +20,13 @@ class ProcessCapturedImageUseCase(
         val spines = runImagePhase { imagePreprocessor.detectShelfItems(image) }
 
         val items = spines.mapIndexed { index, spine ->
+            // Dimensions describe whatever `ref` points at — the cropped spine
+            // file in the normal path, or the full image in fallback paths.
+            // Fall back to whole-image dimensions if the bounding box is degenerate.
             val spineImage = ProcessedImage(
                 ref = spine.cropRef,
-                widthPx = processed.widthPx,
-                heightPx = processed.heightPx
+                widthPx = spineDimension(spine.boundingBox.right - spine.boundingBox.left, processed.widthPx),
+                heightPx = spineDimension(spine.boundingBox.bottom - spine.boundingBox.top, processed.heightPx),
             )
             val ocrResult = runOcrPhase { ocrEngine.recognizeText(spineImage) }
             val parsed = parseItem.execute(ocrResult.blocks)
@@ -89,6 +92,11 @@ class ProcessCapturedImageUseCase(
 
         runSavePhase { scanRepository.saveSession(session) }
         return session
+    }
+
+    private fun spineDimension(spineSize: Float, fallback: Int): Int {
+        val rounded = spineSize.toInt()
+        return if (rounded > 0) rounded else fallback
     }
 
     private inline fun <T> runImagePhase(block: () -> T): T = try {

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ProcessCapturedImageUseCase.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ProcessCapturedImageUseCase.kt
@@ -45,7 +45,7 @@ class ProcessCapturedImageUseCase(
                 ScoreConfidenceUseCase.ScoreInput(
                     segmentationConfidence = spine.confidence,
                     ocrConfidence = ocrConf,
-                    parserConfidence = if (parsed.titleCandidate != null) 0.7 else 0.1,
+                    parserConfidence = parsed.confidence,
                     catalogMatchConfidence = catalogConf,
                     reasons = buildList {
                         if (ocrConf < 0.5) add("low OCR confidence")

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ProcessCapturedImageUseCase.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ProcessCapturedImageUseCase.kt
@@ -16,8 +16,8 @@ class ProcessCapturedImageUseCase(
     private val clock: () -> Long = { 0L }
 ) {
     suspend fun execute(image: CapturedImage, sessionId: String): ScanSession {
-        val processed = imagePreprocessor.normalizeForOcr(image)
-        val spines = imagePreprocessor.detectShelfItems(image)
+        val processed = runImagePhase { imagePreprocessor.normalizeForOcr(image) }
+        val spines = runImagePhase { imagePreprocessor.detectShelfItems(image) }
 
         val items = spines.mapIndexed { index, spine ->
             val spineImage = ProcessedImage(
@@ -25,15 +25,17 @@ class ProcessCapturedImageUseCase(
                 widthPx = processed.widthPx,
                 heightPx = processed.heightPx
             )
-            val ocrResult = ocrEngine.recognizeText(spineImage)
+            val ocrResult = runOcrPhase { ocrEngine.recognizeText(spineImage) }
             val parsed = parseItem.execute(ocrResult.blocks)
 
             val catalogMatches = if (parsed.titleCandidate != null) {
-                metadataLookupService.search(
-                    mediaType = MediaType.BOOK,
-                    title = parsed.titleCandidate,
-                    creatorName = parsed.creatorCandidate
-                )
+                runMetadataPhase {
+                    metadataLookupService.search(
+                        mediaType = MediaType.BOOK,
+                        title = parsed.titleCandidate,
+                        creatorName = parsed.creatorCandidate
+                    )
+                }
             } else emptyList()
 
             val topMatch = catalogMatches.firstOrNull()
@@ -85,7 +87,39 @@ class ProcessCapturedImageUseCase(
             detectedItems = items
         )
 
-        scanRepository.saveSession(session)
+        runSavePhase { scanRepository.saveSession(session) }
         return session
+    }
+
+    private inline fun <T> runImagePhase(block: () -> T): T = try {
+        block()
+    } catch (e: ScanFailure) {
+        throw e
+    } catch (e: Throwable) {
+        throw ScanFailure.ImageProcessing(e)
+    }
+
+    private inline fun <T> runOcrPhase(block: () -> T): T = try {
+        block()
+    } catch (e: ScanFailure) {
+        throw e
+    } catch (e: Throwable) {
+        throw ScanFailure.Ocr(e)
+    }
+
+    private inline fun <T> runMetadataPhase(block: () -> T): T = try {
+        block()
+    } catch (e: ScanFailure) {
+        throw e
+    } catch (e: Throwable) {
+        throw ScanFailure.MetadataLookup(e)
+    }
+
+    private inline fun <T> runSavePhase(block: () -> T): T = try {
+        block()
+    } catch (e: ScanFailure) {
+        throw e
+    } catch (e: Throwable) {
+        throw ScanFailure.Save(e)
     }
 }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ScanFailure.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ScanFailure.kt
@@ -1,0 +1,16 @@
+package com.shelfscan.shared.domain.scan
+
+/**
+ * Typed failure thrown by `ProcessCapturedImageUseCase` so that the
+ * presentation layer can map each pipeline phase to a user-meaningful
+ * `ScanError` without having to grep for exception classes from every
+ * platform's underlying library (ML Kit, Vision, Ktor, etc.).
+ *
+ * The original cause is preserved on `Throwable.cause` for logging.
+ */
+sealed class ScanFailure(cause: Throwable) : RuntimeException(cause.message, cause) {
+    class ImageProcessing(cause: Throwable) : ScanFailure(cause)
+    class Ocr(cause: Throwable) : ScanFailure(cause)
+    class MetadataLookup(cause: Throwable) : ScanFailure(cause)
+    class Save(cause: Throwable) : ScanFailure(cause)
+}

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/SpineClusteringAlgorithm.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/SpineClusteringAlgorithm.kt
@@ -17,9 +17,11 @@ class SpineClusteringAlgorithm(
 
         val sorted = withBoxes.sortedBy { horizontalCentre(it.boundingBox!!) }
 
-        val averageWidth = sorted.map { it.boundingBox!!.right - it.boundingBox.left }
-            .average()
-        val gapThreshold = (averageWidth * gapMultiplier).toFloat()
+        // Median, not mean: a single very wide spine (hardcover next to paperbacks)
+        // would otherwise inflate the threshold and silently merge adjacent narrow
+        // spines into one cluster.
+        val widths = sorted.map { it.boundingBox!!.right - it.boundingBox.left }
+        val gapThreshold = (medianFloat(widths) * gapMultiplier).toFloat()
 
         val clusters = mutableListOf<MutableList<RecognizedTextBlock>>()
         var currentCluster = mutableListOf(sorted.first())
@@ -56,5 +58,12 @@ class SpineClusteringAlgorithm(
             right = boxes.maxOf { it.right },
             bottom = boxes.maxOf { it.bottom }
         )
+    }
+
+    private fun medianFloat(values: List<Float>): Double {
+        val sorted = values.sorted()
+        val n = sorted.size
+        return if (n % 2 == 1) sorted[n / 2].toDouble()
+        else (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
     }
 }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/feature/review/ReviewViewModel.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/feature/review/ReviewViewModel.kt
@@ -109,11 +109,15 @@ class ReviewViewModel(
         scope.launch {
             _state.value = _state.value.copy(isLoading = true)
             try {
+                // Append to any existing collection rather than overwriting it.
+                // Dedup (e.g. by externalId) is intentionally deferred — see #10.
+                val existing = collectionRepository.getCollection(collectionId)
+                val mergedItems = (existing?.items ?: emptyList()) + _state.value.items
                 val collection = Collection(
                     id = collectionId,
-                    name = collectionName,
-                    createdAt = 0L,
-                    items = _state.value.items
+                    name = existing?.name ?: collectionName,
+                    createdAt = existing?.createdAt ?: 0L,
+                    items = mergedItems
                 )
                 collectionRepository.saveCollection(collection)
                 _state.value = _state.value.copy(savedToCollection = true, isLoading = false)

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/feature/scan/ScanViewModel.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/feature/scan/ScanViewModel.kt
@@ -1,8 +1,8 @@
 package com.shelfscan.shared.feature.scan
 
 import com.shelfscan.shared.core.model.*
-import com.shelfscan.shared.data.repository.ScanRepository
 import com.shelfscan.shared.domain.scan.ProcessCapturedImageUseCase
+import com.shelfscan.shared.domain.scan.ScanFailure
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -48,13 +48,21 @@ class ScanViewModel(
                     session = session,
                     isLoading = false
                 )
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 _state.value = ScanState(
                     status = ScanStatus.FAILED,
-                    error = ScanError.OcrFailed,
+                    error = e.toScanError(),
                     isLoading = false
                 )
             }
         }
+    }
+
+    private fun Throwable.toScanError(): ScanError = when (this) {
+        is ScanFailure.ImageProcessing -> ScanError.ImageProcessingFailed
+        is ScanFailure.Ocr -> ScanError.OcrFailed
+        is ScanFailure.MetadataLookup -> ScanError.MetadataLookupFailed
+        is ScanFailure.Save -> ScanError.SaveFailed
+        else -> ScanError.OcrFailed
     }
 }

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/core/geometry/BoundingBoxClampingTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/core/geometry/BoundingBoxClampingTest.kt
@@ -1,0 +1,53 @@
+package com.shelfscan.shared.core.geometry
+
+import com.shelfscan.shared.core.model.BoundingBox
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class BoundingBoxClampingTest {
+
+    @Test
+    fun `box wholly inside image is unchanged`() {
+        val rect = BoundingBox(10f, 20f, 110f, 120f).clampToImage(640, 480)
+        assertEquals(ClampedRect(10, 20, 110, 120), rect)
+    }
+
+    @Test
+    fun `box that overhangs the right and bottom edges is clamped`() {
+        val rect = BoundingBox(500f, 400f, 800f, 600f).clampToImage(640, 480)
+        assertEquals(640, rect.right)
+        assertEquals(480, rect.bottom)
+    }
+
+    @Test
+    fun `negative origins are clamped to zero`() {
+        val rect = BoundingBox(-50f, -30f, 100f, 100f).clampToImage(640, 480)
+        assertEquals(0, rect.left)
+        assertEquals(0, rect.top)
+    }
+
+    @Test
+    fun `degenerate box still has at least one pixel of width and height`() {
+        val rect = BoundingBox(50f, 50f, 50f, 50f).clampToImage(640, 480)
+        assertEquals(1, rect.width)
+        assertEquals(1, rect.height)
+    }
+
+    @Test
+    fun `box entirely beyond the image still produces a one-pixel rect at the edge`() {
+        val rect = BoundingBox(700f, 500f, 800f, 600f).clampToImage(640, 480)
+        // left coerced to 639, right must be > left so coerced to 640.
+        assertEquals(639, rect.left)
+        assertEquals(479, rect.top)
+        assertEquals(1, rect.width)
+        assertEquals(1, rect.height)
+    }
+
+    @Test
+    fun `non-positive image dimensions are rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            BoundingBox(0f, 0f, 10f, 10f).clampToImage(0, 100)
+        }
+    }
+}

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/data/metadata/OpenLibraryMetadataLookupServiceTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/data/metadata/OpenLibraryMetadataLookupServiceTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -152,26 +153,33 @@ class OpenLibraryMetadataLookupServiceTest {
     }
 
     @Test
-    fun `scores decrease monotonically across results`() = runTest {
-        val docs = (1..4).joinToString(",") { i ->
-            """{"title":"Book $i","key":"/works/OL$i"}"""
-        }
-        val service = serviceWith(body = """{"numFound":4,"docs":[$docs]}""")
+    fun `score reflects similarity to query title, not API position`() = runTest {
+        // Three docs returned in API order. The closest token match to "Clean Code"
+        // is the second doc, not the first — score must reflect that.
+        val body = """
+            {"numFound":3,"docs":[
+              {"title":"Cleaning Up","key":"/works/OL1"},
+              {"title":"Clean Code","key":"/works/OL2"},
+              {"title":"Cleanliness","key":"/works/OL3"}
+            ]}
+        """.trimIndent()
+        val service = serviceWith(body = body)
 
-        val matches = service.search(MediaType.BOOK, title = "Book", creatorName = null)
+        val matches = service.search(MediaType.BOOK, title = "Clean Code", creatorName = null)
 
-        assertEquals(4, matches.size)
-        for (i in 1 until matches.size) {
+        assertEquals(3, matches.size)
+        val cleanCode = matches.first { it.title == "Clean Code" }
+        val others = matches.filter { it.title != "Clean Code" }
+        others.forEach { weaker ->
             assertTrue(
-                matches[i - 1].score > matches[i].score,
-                "expected matches[${i - 1}].score (${matches[i - 1].score}) > matches[$i].score (${matches[i].score})"
+                cleanCode.score > weaker.score,
+                "expected '${cleanCode.title}' (${cleanCode.score}) > '${weaker.title}' (${weaker.score})"
             )
         }
     }
 
     @Test
-    fun `score is clamped at zero for low-ranked results`() = runTest {
-        // 12 docs — with step 0.1 the 11th and 12th would go negative without the clamp.
+    fun `scores are bounded between zero and one`() = runTest {
         val docs = (1..12).joinToString(",") { i ->
             """{"title":"Book $i","key":"/works/OL$i"}"""
         }
@@ -189,10 +197,43 @@ class OpenLibraryMetadataLookupServiceTest {
         )
 
         val matches = service.search(MediaType.BOOK, title = "Book", creatorName = null)
+        matches.forEach {
+            assertTrue(it.score in 0.0..1.0, "score must be in [0, 1], got ${it.score}")
+        }
+    }
 
-        assertEquals(12, matches.size)
-        matches.forEach { assertTrue(it.score >= 0.0, "score should never be negative, got ${it.score}") }
-        assertEquals(0.0, matches[10].score)
-        assertEquals(0.0, matches[11].score)
+    @Test
+    fun `request carries a User-Agent header`() = runTest {
+        var capturedUa: String? = null
+        val service = serviceWith(onRequest = {
+            capturedUa = it.headers[HttpHeaders.UserAgent]
+        })
+
+        service.search(MediaType.BOOK, title = "anything", creatorName = null)
+
+        assertNotNull(capturedUa, "User-Agent header must be set")
+        assertTrue(
+            capturedUa!!.contains("ShelfScan", ignoreCase = true),
+            "User-Agent must identify the app: $capturedUa"
+        )
+    }
+
+    @Test
+    fun `slow request times out via HttpTimeout plugin and returns empty list`() = runTest {
+        val engine = MockEngine {
+            kotlinx.coroutines.delay(60_000) // far longer than the configured timeout
+            respond(content = ByteReadChannel("{\"docs\":[]}"), status = HttpStatusCode.OK)
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            install(io.ktor.client.plugins.HttpTimeout) {
+                requestTimeoutMillis = 50
+            }
+        }
+        val service = OpenLibraryMetadataLookupService(client = client)
+
+        val matches = service.search(MediaType.BOOK, title = "Clean Code", creatorName = null)
+
+        assertTrue(matches.isEmpty(), "expected empty list on timeout, got $matches")
     }
 }

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/data/repository/DefaultRepositoryConcurrencyTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/data/repository/DefaultRepositoryConcurrencyTest.kt
@@ -1,0 +1,61 @@
+package com.shelfscan.shared.data.repository
+
+import com.shelfscan.shared.core.model.Collection
+import com.shelfscan.shared.core.model.ImageQualityAssessment
+import com.shelfscan.shared.core.model.ScanSession
+import com.shelfscan.shared.core.model.ScanStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Hammers the in-memory repositories from a multi-threaded dispatcher to
+ * confirm that the Mutex wrap actually protects against lost writes. With the
+ * unprotected `mutableMapOf` these tests fail intermittently (or
+ * `ConcurrentModificationException` is thrown).
+ */
+class DefaultRepositoryConcurrencyTest {
+
+    private val concurrentWriters = 100
+
+    @Test
+    fun `concurrent saveSession does not lose writes`() = runBlocking {
+        val repo = DefaultScanRepository()
+        coroutineScope {
+            (1..concurrentWriters).map { i ->
+                async(Dispatchers.Default) { repo.saveSession(makeSession("session_$i")) }
+            }.awaitAll()
+        }
+        assertEquals(concurrentWriters, repo.getAllSessions().size)
+    }
+
+    @Test
+    fun `concurrent saveCollection does not lose writes`() = runBlocking {
+        val repo = DefaultCollectionRepository()
+        coroutineScope {
+            (1..concurrentWriters).map { i ->
+                async(Dispatchers.Default) {
+                    repo.saveCollection(Collection(id = "c_$i", name = "C$i", createdAt = 0L))
+                }
+            }.awaitAll()
+        }
+        assertEquals(concurrentWriters, repo.getAllCollections().size)
+    }
+
+    private fun makeSession(id: String) = ScanSession(
+        id = id,
+        createdAt = 0L,
+        sourceImageRef = "test.jpg",
+        quality = ImageQualityAssessment(
+            blurScore = 0.0,
+            brightness = 0.5,
+            isAcceptable = true,
+            reasons = emptyList()
+        ),
+        status = ScanStatus.COMPLETE,
+    )
+}

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/ExportCollectionUseCaseTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/ExportCollectionUseCaseTest.kt
@@ -2,9 +2,15 @@ package com.shelfscan.shared.domain
 
 import com.shelfscan.shared.core.model.*
 import com.shelfscan.shared.domain.export.ExportCollectionUseCase
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class ExportCollectionUseCaseTest {
@@ -82,6 +88,35 @@ class ExportCollectionUseCaseTest {
         val csv = useCase.execute(items)
         val lines = csv.lines()
         assertEquals(3, lines.size) // header + 2 items
+    }
+
+    @Test
+    fun `json export escapes control characters in string values per RFC 8259`() {
+        // Real OCR output frequently has newlines and tabs; the spec says these
+        // must be escaped (\n, \t) inside string values. Hand-rolled escaping
+        // in the previous implementation passed them through verbatim, which
+        // strict downstream consumers (Python json, jq, etc.) reject.
+        val item = makeItem(
+            title = "Line one\nLine two",
+            creator = "Author\twith\ttabs"
+        )
+        val json = useCase.execute(listOf(item), ExportCollectionUseCase.ExportFormat.JSON)
+
+        // The escaped substring must appear; the literal control chars must not.
+        assertContains(json, "Line one\\nLine two")
+        assertContains(json, "Author\\twith\\ttabs")
+
+        // And it must round-trip through kotlinx-serialization.
+        val first = Json.parseToJsonElement(json).jsonArray.first() as JsonObject
+        assertEquals("Line one\nLine two", first["title"]!!.jsonPrimitive.content)
+        assertEquals("Author\twith\ttabs", first["creatorName"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `json export of empty list is parseable`() {
+        val json = useCase.execute(emptyList(), ExportCollectionUseCase.ExportFormat.JSON)
+        val element = Json.parseToJsonElement(json)
+        assertTrue(element is JsonArray && element.isEmpty())
     }
 
     @Test

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/ParseDetectedItemUseCaseTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/ParseDetectedItemUseCaseTest.kt
@@ -1,10 +1,12 @@
 package com.shelfscan.shared.domain
 
+import com.shelfscan.shared.core.model.BoundingBox
 import com.shelfscan.shared.core.model.RecognizedTextBlock
 import com.shelfscan.shared.domain.scan.ParseDetectedItemUseCase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ParseDetectedItemUseCaseTest {
     private val useCase = ParseDetectedItemUseCase()
@@ -17,14 +19,54 @@ class ParseDetectedItemUseCaseTest {
     }
 
     @Test
-    fun `picks longest line as title`() {
+    fun `treats line containing an initial as author, not title`() {
+        // "Robert C. Martin" was previously chosen as title because it was longest.
+        // Real bookshelves: an initial like "C." is a strong author signal.
         val blocks = listOf(
             RecognizedTextBlock("Clean Code", 0.9f, null),
             RecognizedTextBlock("Robert C. Martin", 0.85f, null),
             RecognizedTextBlock("A Handbook", 0.7f, null)
         )
         val result = useCase.execute(blocks)
-        assertEquals("Robert C. Martin", result.titleCandidate)
+        assertEquals("Clean Code", result.titleCandidate)
+        assertEquals("Robert C. Martin", result.creatorCandidate)
+    }
+
+    @Test
+    fun `picks line with largest bounding box as title when boxes are available`() {
+        // Title text is normally set in a larger font than the author byline.
+        val blocks = listOf(
+            RecognizedTextBlock("Clean Code", 0.9f, BoundingBox(0f, 0f, 100f, 80f)),     // tall
+            RecognizedTextBlock("by R. Martin", 0.85f, BoundingBox(0f, 100f, 100f, 130f)) // short
+        )
+        val result = useCase.execute(blocks)
+        assertEquals("Clean Code", result.titleCandidate)
+    }
+
+    @Test
+    fun `parser confidence is higher when the initial heuristic fires`() {
+        val withInitial = useCase.execute(
+            listOf(
+                RecognizedTextBlock("Clean Code", 0.9f, null),
+                RecognizedTextBlock("Robert C. Martin", 0.85f, null)
+            )
+        )
+        val withoutInitial = useCase.execute(
+            listOf(
+                RecognizedTextBlock("Some Title", 0.9f, null),
+                RecognizedTextBlock("Some Author", 0.85f, null)
+            )
+        )
+        assertTrue(
+            withInitial.confidence > withoutInitial.confidence,
+            "expected initial-driven parse (${withInitial.confidence}) > fallback (${withoutInitial.confidence})"
+        )
+    }
+
+    @Test
+    fun `confidence is minimal when there are no candidates`() {
+        val result = useCase.execute(emptyList())
+        assertTrue(result.confidence <= 0.1)
     }
 
     @Test

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/ProcessCapturedImageUseCaseTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/ProcessCapturedImageUseCaseTest.kt
@@ -60,7 +60,7 @@ class ProcessCapturedImageUseCaseTest {
     }
 
     @Test
-    fun `execute with multi-line OCR picks longest as title`() { runBlocking {
+    fun `execute with multi-line OCR picks the title and author correctly`() { runBlocking {
         val multiLineEngine = object : OcrEngine {
             override suspend fun recognizeText(image: ProcessedImage): OcrResult {
                 return OcrResult(
@@ -85,7 +85,8 @@ class ProcessCapturedImageUseCaseTest {
         val session = useCase.execute(image, "test_multi")
 
         val item = session.detectedItems.first()
-        assertEquals("Robert C. Martin", item.title) // longest line
+        assertEquals("Clean Code", item.title)
+        assertEquals("Robert C. Martin", item.creatorName)
         assertEquals(3, item.rawText.size)
     } }
 

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/SpineClusteringAlgorithmTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/SpineClusteringAlgorithmTest.kt
@@ -119,6 +119,21 @@ class SpineClusteringAlgorithmTest {
     }
 
     @Test
+    fun oneWideBookDoesNotMergeNarrowNeighbours() {
+        // One wide hardcover at the right next to three narrow paperbacks on the left.
+        // A mean-based threshold gets inflated by the wide book and merges adjacent
+        // narrow spines together. A median-based threshold is robust to this.
+        val blocks = listOf(
+            block("paperback A", 0f, 0f, 30f, 200f),       // width 30
+            block("paperback B", 50f, 0f, 80f, 200f),      // width 30, gap 20
+            block("paperback C", 100f, 0f, 130f, 200f),    // width 30, gap 20
+            block("hardcover",   200f, 0f, 400f, 200f)     // width 200, gap 70
+        )
+        val result = algorithm.cluster(blocks)
+        assertEquals(4, result.size, "each book should remain its own cluster")
+    }
+
+    @Test
     fun overlappingBlocksInSameRegionClusterTogether() {
         val blocks = listOf(
             block("Part A", 10f, 0f, 60f, 100f),

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/integration/ReviewWorkflowIntegrationTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/integration/ReviewWorkflowIntegrationTest.kt
@@ -129,6 +129,25 @@ class ReviewWorkflowIntegrationTest {
     }
 
     @Test
+    fun `saving to same collection twice accumulates items`() {
+        // Scan 1
+        loadSession(makeMediaItem(id = "a", title = "Clean Code"))
+        viewModel.onAction(ReviewAction.SaveToCollection("col_acc", "Library"))
+        testScope.advanceUntilIdle()
+
+        // Scan 2 — fresh review session, same target collection
+        viewModel.onAction(ReviewAction.DiscardAll)
+        loadSession(makeMediaItem(id = "b", title = "Refactoring"))
+        viewModel.onAction(ReviewAction.SaveToCollection("col_acc", "Library"))
+        testScope.advanceUntilIdle()
+
+        val saved = getSavedCollection("col_acc")
+        assertEquals(2, saved.items.size, "second save must append, not overwrite")
+        assertTrue(saved.items.any { it.id == "a" })
+        assertTrue(saved.items.any { it.id == "b" })
+    }
+
+    @Test
     fun `discard all clears state`() {
         loadSession(
             makeMediaItem(id = "item_0"),

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/integration/ScanViewModelIntegrationTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/integration/ScanViewModelIntegrationTest.kt
@@ -1,12 +1,17 @@
 package com.shelfscan.shared.integration
 
+import com.shelfscan.shared.core.model.CatalogMatch
+import com.shelfscan.shared.core.model.MediaType
 import com.shelfscan.shared.core.model.ScanError
+import com.shelfscan.shared.core.model.ScanSession
 import com.shelfscan.shared.core.model.ScanStatus
 import com.shelfscan.shared.data.repository.DefaultScanRepository
+import com.shelfscan.shared.data.repository.ScanRepository
 import com.shelfscan.shared.domain.scan.ProcessCapturedImageUseCase
 import com.shelfscan.shared.feature.scan.ScanAction
 import com.shelfscan.shared.feature.scan.ScanState
 import com.shelfscan.shared.feature.scan.ScanViewModel
+import com.shelfscan.shared.platform.MetadataLookupService
 import com.shelfscan.shared.platform.NoOpMetadataLookupService
 import com.shelfscan.shared.platform.PassthroughImagePreprocessor
 import kotlinx.coroutines.test.TestScope
@@ -79,7 +84,7 @@ class ScanViewModelIntegrationTest {
     }
 
     @Test
-    fun `OCR failure produces error state`() {
+    fun `OCR failure maps to OcrFailed error`() {
         val (viewModel, scope) = createViewModel(
             ocrEngine = ConfigurableFakeOcrEngine(shouldThrow = true)
         )
@@ -92,6 +97,53 @@ class ScanViewModelIntegrationTest {
         assertEquals(ScanError.OcrFailed, state.error)
         assertFalse(state.isLoading)
         assertNull(state.session)
+    }
+
+    @Test
+    fun `metadata failure maps to MetadataLookupFailed error`() {
+        val scope = TestScope()
+        val throwingMetadata = object : MetadataLookupService {
+            override suspend fun search(
+                mediaType: MediaType,
+                title: String?,
+                creatorName: String?
+            ): List<CatalogMatch> = throw RuntimeException("upstream went down")
+        }
+        val useCase = ProcessCapturedImageUseCase(
+            imagePreprocessor = PassthroughImagePreprocessor(),
+            ocrEngine = ConfigurableFakeOcrEngine(defaultResult = ocrResultFor("Some Book")),
+            metadataLookupService = throwingMetadata,
+            scanRepository = DefaultScanRepository()
+        )
+        val viewModel = ScanViewModel(processImage = useCase, scope = scope)
+
+        viewModel.onAction(ScanAction.CaptureImage(testImage))
+        scope.advanceUntilIdle()
+
+        assertEquals(ScanError.MetadataLookupFailed, viewModel.state.value.error)
+    }
+
+    @Test
+    fun `repository save failure maps to SaveFailed error`() {
+        val scope = TestScope()
+        val throwingRepo = object : ScanRepository {
+            override suspend fun saveSession(session: ScanSession): Unit =
+                throw RuntimeException("disk full")
+            override suspend fun getSession(id: String): ScanSession? = null
+            override suspend fun getAllSessions(): List<ScanSession> = emptyList()
+        }
+        val useCase = ProcessCapturedImageUseCase(
+            imagePreprocessor = PassthroughImagePreprocessor(),
+            ocrEngine = ConfigurableFakeOcrEngine(),
+            metadataLookupService = NoOpMetadataLookupService(),
+            scanRepository = throwingRepo
+        )
+        val viewModel = ScanViewModel(processImage = useCase, scope = scope)
+
+        viewModel.onAction(ScanAction.CaptureImage(testImage))
+        scope.advanceUntilIdle()
+
+        assertEquals(ScanError.SaveFailed, viewModel.state.value.error)
     }
 
     @Test

--- a/shelfscan/shared/src/iosMain/kotlin/com/shelfscan/shared/platform/IosShelfScanFactory.kt
+++ b/shelfscan/shared/src/iosMain/kotlin/com/shelfscan/shared/platform/IosShelfScanFactory.kt
@@ -5,6 +5,7 @@ import com.shelfscan.shared.data.repository.DefaultScanRepository
 import com.shelfscan.shared.data.repository.ScanRepository
 import com.shelfscan.shared.domain.scan.ProcessCapturedImageUseCase
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -43,6 +44,10 @@ object IosShelfScanFactory {
         val client = HttpClient {
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 5_000
+                connectTimeoutMillis = 5_000
             }
         }
         return OpenLibraryMetadataLookupService(client = client)


### PR DESCRIPTION
Addresses every issue in milestone **MVP P0 — Android demo blockers**.

## Commits

| Commit | Issue | Summary |
|---|---|---|
| 96f5f2b | #11 | Dedupe ML Kit Text→RecognizedTextBlock mapping |
| 1ae98f5 | #9  | Crop spines via BitmapRegionDecoder, not full-image decode |
| fd814a4 | #12 | Title parser: bbox font size + initial pattern, drop magic 0.7/0.1 |
| d58267a | #7  | Survive Activity recreation: ShelfScanApplication + AndroidViewModels |
| 787ff73 | #10 | SaveToCollection appends instead of overwriting |
| ca37757 | #8  | Typed ScanFailure → ScanError mapping with error-specific UI copy |

## Test plan

- [x] All 96 shared-module tests pass: `gradle21w :shared:jvmTest`
- [x] Android debug build clean: `gradle21w :androidApp:assembleDebug`
- [ ] Manual: rotate the device during review — items survive
- [ ] Manual: scan two shelves into the same collection — both sets persist
- [ ] Manual: trigger each failure mode (airplane mode → MetadataLookupFailed copy; bad image → ImageProcessingFailed copy)
- [ ] Manual: scan a real shelf with a tall book → verify no OOM (target: 20+ books on a low-end device)

## Notes

- ML Kit recogniser sharing/close, HttpClient close, and repository thread-safety remain scoped to #19 (P1).
- Save-merge dedup (e.g. by externalId) is intentionally deferred — see #10's body.
- Compose `LocalLifecycleOwner` deprecation warning is pre-existing, untouched.