### PR TITLE
Fix P1 Android robustness (#13-#19)

### DIFF
--- a/shelfscan/androidApp/build.gradle.kts
+++ b/shelfscan/androidApp/build.gradle.kts
@@ -70,7 +70,6 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
     implementation(libs.compose.activity)
-    implementation(libs.appcompat)
 
     // CameraX
     implementation(libs.camerax.core)

--- a/shelfscan/androidApp/src/androidTest/kotlin/com/shelfscan/android/image/OcrBasedSpineDetectorTest.kt
+++ b/shelfscan/androidApp/src/androidTest/kotlin/com/shelfscan/android/image/OcrBasedSpineDetectorTest.kt
@@ -1,6 +1,9 @@
 package com.shelfscan.android.image
 
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.shelfscan.android.test.TestImageLoader
 import com.shelfscan.shared.core.model.CapturedImage
 import kotlinx.coroutines.runBlocking
@@ -14,13 +17,15 @@ import kotlin.test.assertTrue
 class OcrBasedSpineDetectorTest {
 
     private lateinit var detector: OcrBasedSpineDetector
+    private lateinit var recognizer: TextRecognizer
     private lateinit var imageLoader: TestImageLoader
     private lateinit var testImagePath: String
 
     @Before
     fun setUp() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        detector = OcrBasedSpineDetector(context)
+        recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+        detector = OcrBasedSpineDetector(context, recognizer)
         imageLoader = TestImageLoader()
         testImagePath = imageLoader.loadAsset("test_bookshelf.jpg")
     }
@@ -28,6 +33,7 @@ class OcrBasedSpineDetectorTest {
     @After
     fun tearDown() {
         imageLoader.cleanup()
+        recognizer.close()
     }
 
     @Test

--- a/shelfscan/androidApp/src/androidTest/kotlin/com/shelfscan/android/ocr/MlKitOcrAdapterTest.kt
+++ b/shelfscan/androidApp/src/androidTest/kotlin/com/shelfscan/android/ocr/MlKitOcrAdapterTest.kt
@@ -1,6 +1,9 @@
 package com.shelfscan.android.ocr
 
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.shelfscan.android.test.TestImageLoader
 import com.shelfscan.shared.core.model.ProcessedImage
 import kotlinx.coroutines.runBlocking
@@ -13,13 +16,15 @@ import kotlin.test.assertTrue
 class MlKitOcrAdapterTest {
 
     private lateinit var adapter: MlKitOcrAdapter
+    private lateinit var recognizer: TextRecognizer
     private lateinit var imageLoader: TestImageLoader
     private lateinit var testImagePath: String
 
     @Before
     fun setUp() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        adapter = MlKitOcrAdapter(context)
+        recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+        adapter = MlKitOcrAdapter(context, recognizer)
         imageLoader = TestImageLoader()
         testImagePath = imageLoader.loadAsset("test_bookshelf.jpg")
     }
@@ -27,6 +32,7 @@ class MlKitOcrAdapterTest {
     @After
     fun tearDown() {
         imageLoader.cleanup()
+        recognizer.close()
     }
 
     @Test

--- a/shelfscan/androidApp/src/main/AndroidManifest.xml
+++ b/shelfscan/androidApp/src/main/AndroidManifest.xml
@@ -7,11 +7,14 @@
     <application
         android:name=".ShelfScanApplication"
         android:label="ShelfScan"
-        android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.ShelfScan">
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+            android:theme="@style/Theme.ShelfScan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/MainActivity.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/MainActivity.kt
@@ -198,17 +198,26 @@ fun ScanScreen(
                 }
             }
             else -> {
+                // Local in-flight flag avoids the race window between tap and
+                // ScanState.isLoading flipping. Without it, fast double-taps
+                // launch concurrent cameraAdapter.captureImage() calls.
+                var isCapturing by remember { mutableStateOf(false) }
                 Button(
                     onClick = {
+                        if (isCapturing) return@Button
+                        isCapturing = true
                         coroutineScope.launch {
                             try {
                                 val image = cameraAdapter.captureImage()
                                 scanViewModel.onAction(ScanAction.CaptureImage(image))
                             } catch (_: Exception) {
                                 scanViewModel.onAction(ScanAction.RetryCapture)
+                            } finally {
+                                isCapturing = false
                             }
                         }
                     },
+                    enabled = !isCapturing,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(24.dp)

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ShelfScanApplication.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ShelfScanApplication.kt
@@ -1,6 +1,9 @@
 package com.shelfscan.android
 
 import android.app.Application
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.shelfscan.android.image.OcrBasedSpineDetector
 import com.shelfscan.android.ocr.MlKitOcrAdapter
 import com.shelfscan.shared.data.metadata.OpenLibraryMetadataLookupService
@@ -28,6 +31,7 @@ import kotlinx.serialization.json.Json
 class ShelfScanApplication : Application() {
 
     private lateinit var httpClient: HttpClient
+    private lateinit var textRecognizer: TextRecognizer
 
     lateinit var scanRepository: DefaultScanRepository
         private set
@@ -47,13 +51,28 @@ class ShelfScanApplication : Application() {
                 connectTimeoutMillis = 5_000
             }
         }
+        // One ML Kit recogniser shared by both the OCR adapter and the
+        // OCR-based segmenter. Loading the latin model is expensive — doing it
+        // twice per Activity recreation was the previous default.
+        textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+
         scanRepository = DefaultScanRepository()
         collectionRepository = DefaultCollectionRepository()
         processCapturedImageUseCase = ProcessCapturedImageUseCase(
-            imagePreprocessor = OcrBasedSpineDetector(this),
-            ocrEngine = MlKitOcrAdapter(this),
+            imagePreprocessor = OcrBasedSpineDetector(this, textRecognizer),
+            ocrEngine = MlKitOcrAdapter(this, textRecognizer),
             metadataLookupService = OpenLibraryMetadataLookupService(httpClient),
             scanRepository = scanRepository,
         )
+    }
+
+    override fun onTerminate() {
+        // Best-effort cleanup. Android docs note onTerminate is not guaranteed
+        // to fire in production — a full process-shutdown leak protection
+        // would need a different mechanism. Either way, we no longer leak
+        // these per Activity recreation, which was the actual bug.
+        if (::httpClient.isInitialized) httpClient.close()
+        if (::textRecognizer.isInitialized) textRecognizer.close()
+        super.onTerminate()
     }
 }

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ShelfScanApplication.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ShelfScanApplication.kt
@@ -9,6 +9,7 @@ import com.shelfscan.shared.data.repository.DefaultScanRepository
 import com.shelfscan.shared.domain.scan.ProcessCapturedImageUseCase
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -40,6 +41,10 @@ class ShelfScanApplication : Application() {
         httpClient = HttpClient(OkHttp) {
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 5_000
+                connectTimeoutMillis = 5_000
             }
         }
         scanRepository = DefaultScanRepository()

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/image/OcrBasedSpineDetector.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/image/OcrBasedSpineDetector.kt
@@ -4,8 +4,7 @@ import android.content.Context
 import android.graphics.BitmapFactory
 import android.net.Uri
 import com.google.mlkit.vision.common.InputImage
-import com.google.mlkit.vision.text.TextRecognition
-import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.google.mlkit.vision.text.TextRecognizer
 import com.shelfscan.android.ocr.toRecognizedTextBlocks
 import com.shelfscan.shared.core.model.BoundingBox
 import com.shelfscan.shared.core.model.CapturedImage
@@ -20,11 +19,10 @@ import kotlin.coroutines.resume
 
 class OcrBasedSpineDetector(
     private val context: Context,
+    private val recogniser: TextRecognizer,
     private val clusterAlgorithm: SpineClusteringAlgorithm = SpineClusteringAlgorithm(),
     private val bitmapCropper: BitmapCropper = BitmapCropper(context.cacheDir)
 ) : ImagePreprocessor {
-
-    private val recogniser = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
 
     override suspend fun normalizeForOcr(image: CapturedImage): ProcessedImage {
         return ProcessedImage(

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ocr/MlKitOcrAdapter.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ocr/MlKitOcrAdapter.kt
@@ -3,8 +3,7 @@ package com.shelfscan.android.ocr
 import android.content.Context
 import android.net.Uri
 import com.google.mlkit.vision.common.InputImage
-import com.google.mlkit.vision.text.TextRecognition
-import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.google.mlkit.vision.text.TextRecognizer
 import com.shelfscan.shared.core.model.OcrResult
 import com.shelfscan.shared.core.model.ProcessedImage
 import com.shelfscan.shared.platform.OcrEngine
@@ -13,8 +12,15 @@ import java.io.File
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-class MlKitOcrAdapter(private val context: Context) : OcrEngine {
-    private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+/**
+ * Adapter from the shared `OcrEngine` contract to ML Kit's `TextRecognizer`.
+ * The recognizer is constructed once in `ShelfScanApplication` and shared
+ * with `OcrBasedSpineDetector` to avoid loading the model twice.
+ */
+class MlKitOcrAdapter(
+    private val context: Context,
+    private val recognizer: TextRecognizer,
+) : OcrEngine {
 
     override suspend fun recognizeText(image: ProcessedImage): OcrResult =
         suspendCancellableCoroutine { continuation ->

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ui/ReviewScreen.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/ui/ReviewScreen.kt
@@ -18,6 +18,7 @@ import com.shelfscan.shared.core.model.ConfidenceBand
 import com.shelfscan.shared.core.model.ItemSource
 import com.shelfscan.shared.core.model.MediaItem
 import com.shelfscan.shared.core.model.MediaType
+import com.shelfscan.shared.core.model.ScanError
 import com.shelfscan.shared.feature.review.ReviewAction
 import com.shelfscan.shared.feature.review.ReviewState
 import com.shelfscan.shared.feature.review.ReviewViewModel
@@ -157,48 +158,107 @@ fun ReviewScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        if (reviewState.savedToCollection) {
-            Text("Saved!", style = MaterialTheme.typography.bodyLarge)
-            Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = onDone, modifier = Modifier.fillMaxWidth()) {
-                Text("Back to Home")
+        reviewState.error?.let { error ->
+            Text(
+                text = reviewErrorMessage(error),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+
+        when {
+            reviewState.savedToCollection -> {
+                Text("Saved!", style = MaterialTheme.typography.bodyLarge)
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = onDone, modifier = Modifier.fillMaxWidth()) {
+                    Text("Back to Home")
+                }
             }
-        } else {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Button(
-                    onClick = {
-                        reviewViewModel.onAction(
-                            ReviewAction.SaveToCollection(
-                                collectionId = "default",
-                                collectionName = "My Books"
+            reviewState.isLoading -> {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text("Saving…")
+                }
+            }
+            else -> {
+                var showDiscardConfirm by remember { mutableStateOf(false) }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Button(
+                        onClick = {
+                            reviewViewModel.onAction(
+                                ReviewAction.SaveToCollection(
+                                    collectionId = "default",
+                                    collectionName = "My Books"
+                                )
                             )
-                        )
-                    },
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text("Save")
+                        },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("Save")
+                    }
+                    FilledTonalButton(
+                        onClick = { reviewViewModel.onAction(ReviewAction.ApproveAll) },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("Approve All")
+                    }
+                    OutlinedButton(
+                        onClick = { showDiscardConfirm = true },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("Discard")
+                    }
                 }
-                FilledTonalButton(
-                    onClick = { reviewViewModel.onAction(ReviewAction.ApproveAll) },
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text("Approve All")
-                }
-                OutlinedButton(
-                    onClick = {
-                        reviewViewModel.onAction(ReviewAction.DiscardAll)
-                        onDone()
-                    },
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text("Discard")
+
+                if (showDiscardConfirm) {
+                    AlertDialog(
+                        onDismissRequest = { showDiscardConfirm = false },
+                        title = { Text("Discard scan?") },
+                        text = {
+                            Text(
+                                "This removes all ${reviewState.items.size} detected " +
+                                    "items. You can't undo this."
+                            )
+                        },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                showDiscardConfirm = false
+                                reviewViewModel.onAction(ReviewAction.DiscardAll)
+                                onDone()
+                            }) {
+                                Text("Discard", color = MaterialTheme.colorScheme.error)
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showDiscardConfirm = false }) {
+                                Text("Cancel")
+                            }
+                        }
+                    )
                 }
             }
         }
     }
+}
+
+private fun reviewErrorMessage(error: ScanError): String = when (error) {
+    ScanError.SaveFailed -> "Couldn't save the collection. Please try again."
+    ScanError.MetadataLookupFailed -> "Couldn't look up book details right now."
+    ScanError.OcrFailed -> "Couldn't read text on the spines."
+    ScanError.ImageProcessingFailed -> "Couldn't process the photo."
+    ScanError.CameraUnavailable -> "Camera unavailable."
+    ScanError.PermissionDenied -> "Camera permission required."
+    ScanError.ImageTooBlurry -> "Photo was too blurry."
 }
 
 @Composable

--- a/shelfscan/androidApp/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/shelfscan/androidApp/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <!-- Stylised stack of three books on a shelf, drawn within the safe area
+         (centred 72×72 box at offset 18,18). -->
+    <group android:translateX="20" android:translateY="22">
+        <!-- Tall book -->
+        <path android:fillColor="#FFFFFF" android:pathData="M6,10 h12 v54 h-12 z" />
+        <!-- Medium book, slightly tilted right via gradient stroke -->
+        <path android:fillColor="#FFFFFF" android:pathData="M22,16 h12 v48 h-12 z" />
+        <!-- Short fat book -->
+        <path android:fillColor="#FFFFFF" android:pathData="M38,24 h22 v40 h-22 z" />
+        <!-- Shelf line -->
+        <path android:fillColor="#FFFFFF" android:pathData="M2,64 h62 v3 h-62 z" />
+    </group>
+</vector>

--- a/shelfscan/androidApp/src/main/res/layout/activity_main.xml
+++ b/shelfscan/androidApp/src/main/res/layout/activity_main.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent" />

--- a/shelfscan/androidApp/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/shelfscan/androidApp/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/shelfscan/androidApp/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/shelfscan/androidApp/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/shelfscan/androidApp/src/main/res/values/colors.xml
+++ b/shelfscan/androidApp/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#1976D2</color>
+</resources>

--- a/shelfscan/androidApp/src/main/res/values/themes.xml
+++ b/shelfscan/androidApp/src/main/res/values/themes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+      Activity-side theme is intentionally minimal: Compose draws the rest of
+      the UI. This theme exists only to give the activity a sane no-action-bar
+      base before setContent { } takes over, and to drop the AppCompat
+      dependency that the previous Theme.AppCompat.DayNight.NoActionBar
+      pulled in.
+    -->
+    <style name="Theme.ShelfScan" parent="android:Theme.Material.Light.NoActionBar" />
+</resources>

--- a/shelfscan/gradle/libs.versions.toml
+++ b/shelfscan/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ androidxTestRunner = "1.6.2"
 androidxTestRules = "1.6.1"
 androidxTestExtJunit = "1.2.1"
 activityCompose = "1.13.0"
-appcompat = "1.7.1"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -53,7 +52,6 @@ compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 
 # Test
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/metadata/OpenLibraryMetadataLookupService.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/metadata/OpenLibraryMetadataLookupService.kt
@@ -7,15 +7,28 @@ import com.shelfscan.shared.platform.MetadataLookupService
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Looks up books in the Open Library API.
+ *
+ * Request timeouts are the responsibility of the supplied `client` — install
+ * the `HttpTimeout` plugin with sane bounds at construction time, e.g.
+ * `install(HttpTimeout) { requestTimeoutMillis = 5_000 }`. We can't enforce a
+ * timeout from inside this class portably (kotlinx.coroutines.withTimeout
+ * misbehaves under runTest's virtual time, and Ktor's per-request timeout DSL
+ * needs the plugin installed regardless).
+ */
 class OpenLibraryMetadataLookupService(
     private val client: HttpClient,
     private val baseUrl: String = "https://openlibrary.org",
     private val resultLimit: Int = 5,
+    private val userAgent: String = DEFAULT_USER_AGENT,
 ) : MetadataLookupService {
 
     override suspend fun search(
@@ -30,11 +43,13 @@ class OpenLibraryMetadataLookupService(
 
         val response: HttpResponse = try {
             client.get("$baseUrl/search.json") {
+                header(HttpHeaders.UserAgent, userAgent)
                 if (titleQ.isNotEmpty()) url.parameters.append("title", titleQ)
                 if (creatorQ.isNotEmpty()) url.parameters.append("author", creatorQ)
                 url.parameters.append("limit", resultLimit.toString())
             }
         } catch (e: Throwable) {
+            // Network failure, timeout, host unreachable — degrade gracefully.
             return emptyList()
         }
 
@@ -46,21 +61,58 @@ class OpenLibraryMetadataLookupService(
             return emptyList()
         }
 
-        return payload.docs.mapIndexed { index, doc ->
+        return payload.docs.map { doc ->
             CatalogMatch(
                 source = CatalogSource(SOURCE_NAME),
                 mediaType = MediaType.BOOK,
                 title = doc.title.orEmpty(),
                 creatorName = doc.authorName?.firstOrNull(),
                 year = doc.firstPublishYear,
-                score = (1.0 - index * 0.1).coerceAtLeast(0.0),
+                score = scoreMatch(
+                    queryTitle = titleQ,
+                    queryAuthor = creatorQ,
+                    docTitle = doc.title.orEmpty(),
+                    docAuthor = doc.authorName?.firstOrNull().orEmpty(),
+                ),
                 externalId = doc.key.orEmpty(),
             )
         }
     }
 
+    /**
+     * Score a candidate by token-Jaccard similarity against the query.
+     * Title carries 70% of the weight, author 30% — and only if the user
+     * supplied an author query, otherwise we score on title alone.
+     */
+    private fun scoreMatch(
+        queryTitle: String,
+        queryAuthor: String,
+        docTitle: String,
+        docAuthor: String,
+    ): Double {
+        val titleSim = jaccard(tokenize(queryTitle), tokenize(docTitle))
+        if (queryAuthor.isBlank()) return titleSim
+        val authorSim = jaccard(tokenize(queryAuthor), tokenize(docAuthor))
+        return TITLE_WEIGHT * titleSim + AUTHOR_WEIGHT * authorSim
+    }
+
+    private fun tokenize(text: String): Set<String> =
+        text.lowercase().split(TOKEN_SEPARATOR).filter { it.isNotBlank() }.toSet()
+
+    private fun jaccard(a: Set<String>, b: Set<String>): Double {
+        if (a.isEmpty() || b.isEmpty()) return 0.0
+        val intersection = a.intersect(b).size
+        val union = a.union(b).size
+        return intersection.toDouble() / union.toDouble()
+    }
+
     companion object {
         const val SOURCE_NAME = "OpenLibrary"
+        const val DEFAULT_USER_AGENT = "ShelfScan/1.0 (https://github.com/bovinemagnet/BookShelfScanner)"
+
+        private const val TITLE_WEIGHT = 0.7
+        private const val AUTHOR_WEIGHT = 0.3
+        private val TOKEN_SEPARATOR = Regex("[\\s\\p{Punct}]+")
     }
 }
 

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/repository/DefaultCollectionRepository.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/repository/DefaultCollectionRepository.kt
@@ -2,23 +2,36 @@ package com.shelfscan.shared.data.repository
 
 import com.shelfscan.shared.core.model.Collection
 import com.shelfscan.shared.core.model.MediaItem
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
+/**
+ * In-memory `CollectionRepository`. Reads and writes are serialised through a
+ * `Mutex` so concurrent saves from review coroutines can't race on the
+ * underlying map.
+ */
 class DefaultCollectionRepository : CollectionRepository {
+    private val mutex = Mutex()
     private val collections = mutableMapOf<String, Collection>()
 
-    override suspend fun saveCollection(collection: Collection) {
+    override suspend fun saveCollection(collection: Collection) = mutex.withLock {
         collections[collection.id] = collection
     }
 
-    override suspend fun getCollection(id: String): Collection? = collections[id]
-
-    override suspend fun saveItems(collectionId: String, items: List<MediaItem>) {
-        val collection = collections[collectionId] ?: return
-        collections[collectionId] = collection.copy(items = items)
+    override suspend fun getCollection(id: String): Collection? = mutex.withLock {
+        collections[id]
     }
 
-    override suspend fun getCollectionItems(collectionId: String): List<MediaItem> =
-        collections[collectionId]?.items ?: emptyList()
+    override suspend fun saveItems(collectionId: String, items: List<MediaItem>) = mutex.withLock {
+        val existing = collections[collectionId] ?: return@withLock
+        collections[collectionId] = existing.copy(items = items)
+    }
 
-    override suspend fun getAllCollections(): List<Collection> = collections.values.toList()
+    override suspend fun getCollectionItems(collectionId: String): List<MediaItem> = mutex.withLock {
+        collections[collectionId]?.items ?: emptyList()
+    }
+
+    override suspend fun getAllCollections(): List<Collection> = mutex.withLock {
+        collections.values.toList()
+    }
 }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/repository/DefaultScanRepository.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/data/repository/DefaultScanRepository.kt
@@ -1,15 +1,27 @@
 package com.shelfscan.shared.data.repository
 
 import com.shelfscan.shared.core.model.ScanSession
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
+/**
+ * In-memory `ScanRepository`. Reads and writes are serialised through a
+ * `Mutex` so concurrent calls from camera, OCR, and review coroutines can't
+ * race on the underlying map.
+ */
 class DefaultScanRepository : ScanRepository {
+    private val mutex = Mutex()
     private val sessions = mutableMapOf<String, ScanSession>()
 
-    override suspend fun saveSession(session: ScanSession) {
+    override suspend fun saveSession(session: ScanSession) = mutex.withLock {
         sessions[session.id] = session
     }
 
-    override suspend fun getSession(id: String): ScanSession? = sessions[id]
+    override suspend fun getSession(id: String): ScanSession? = mutex.withLock {
+        sessions[id]
+    }
 
-    override suspend fun getAllSessions(): List<ScanSession> = sessions.values.toList()
+    override suspend fun getAllSessions(): List<ScanSession> = mutex.withLock {
+        sessions.values.toList()
+    }
 }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/export/ExportCollectionUseCase.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/export/ExportCollectionUseCase.kt
@@ -1,6 +1,9 @@
 package com.shelfscan.shared.domain.export
 
 import com.shelfscan.shared.core.model.MediaItem
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
 
 class ExportCollectionUseCase {
     enum class ExportFormat { CSV, JSON }
@@ -28,12 +31,17 @@ class ExportCollectionUseCase {
         return (listOf(header) + rows).joinToString("\n")
     }
 
-    private fun toJson(items: List<MediaItem>): String {
-        val entries = items.joinToString(",\n  ") { item ->
-            """{"id":"${item.id}","mediaType":"${item.mediaType}","title":${item.title?.let { "\"${it.escapeJson()}\"" } ?: "null"},"creatorName":${item.creatorName?.let { "\"${it.escapeJson()}\"" } ?: "null"},"confidence":${item.confidence.value},"source":"${item.source}"}"""
-        }
-        return "[\n  $entries\n]"
-    }
+    private fun toJson(items: List<MediaItem>): String =
+        json.encodeToString(ListSerializer(MediaItemDto.serializer()), items.map { it.toDto() })
+
+    private fun MediaItem.toDto() = MediaItemDto(
+        id = id,
+        mediaType = mediaType.name,
+        title = title,
+        creatorName = creatorName,
+        confidence = confidence.value,
+        source = source.name,
+    )
 
     private fun String.escapeCsv(): String {
         return if (contains(',') || contains('"') || contains('\n')) {
@@ -41,6 +49,20 @@ class ExportCollectionUseCase {
         } else this
     }
 
-    private fun String.escapeJson(): String =
-        replace("\\", "\\\\").replace("\"", "\\\"")
+    private companion object {
+        // prettyPrint matches the previous output style closely while letting
+        // kotlinx-serialization handle all RFC-8259 escaping correctly.
+        val json = Json { prettyPrint = true; encodeDefaults = false }
+    }
+
+    /** Stable wire format for exported items — decoupled from the rich domain model. */
+    @Serializable
+    private data class MediaItemDto(
+        val id: String,
+        val mediaType: String,
+        val title: String?,
+        val creatorName: String?,
+        val confidence: Double,
+        val source: String,
+    )
 }

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ProcessCapturedImageUseCase.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/ProcessCapturedImageUseCase.kt
@@ -20,10 +20,13 @@ class ProcessCapturedImageUseCase(
         val spines = runImagePhase { imagePreprocessor.detectShelfItems(image) }
 
         val items = spines.mapIndexed { index, spine ->
+            // Dimensions describe whatever `ref` points at — the cropped spine
+            // file in the normal path, or the full image in fallback paths.
+            // Fall back to whole-image dimensions if the bounding box is degenerate.
             val spineImage = ProcessedImage(
                 ref = spine.cropRef,
-                widthPx = processed.widthPx,
-                heightPx = processed.heightPx
+                widthPx = spineDimension(spine.boundingBox.right - spine.boundingBox.left, processed.widthPx),
+                heightPx = spineDimension(spine.boundingBox.bottom - spine.boundingBox.top, processed.heightPx),
             )
             val ocrResult = runOcrPhase { ocrEngine.recognizeText(spineImage) }
             val parsed = parseItem.execute(ocrResult.blocks)
@@ -89,6 +92,11 @@ class ProcessCapturedImageUseCase(
 
         runSavePhase { scanRepository.saveSession(session) }
         return session
+    }
+
+    private fun spineDimension(spineSize: Float, fallback: Int): Int {
+        val rounded = spineSize.toInt()
+        return if (rounded > 0) rounded else fallback
     }
 
     private inline fun <T> runImagePhase(block: () -> T): T = try {

--- a/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/SpineClusteringAlgorithm.kt
+++ b/shelfscan/shared/src/commonMain/kotlin/com/shelfscan/shared/domain/scan/SpineClusteringAlgorithm.kt
@@ -17,9 +17,11 @@ class SpineClusteringAlgorithm(
 
         val sorted = withBoxes.sortedBy { horizontalCentre(it.boundingBox!!) }
 
-        val averageWidth = sorted.map { it.boundingBox!!.right - it.boundingBox.left }
-            .average()
-        val gapThreshold = (averageWidth * gapMultiplier).toFloat()
+        // Median, not mean: a single very wide spine (hardcover next to paperbacks)
+        // would otherwise inflate the threshold and silently merge adjacent narrow
+        // spines into one cluster.
+        val widths = sorted.map { it.boundingBox!!.right - it.boundingBox.left }
+        val gapThreshold = (medianFloat(widths) * gapMultiplier).toFloat()
 
         val clusters = mutableListOf<MutableList<RecognizedTextBlock>>()
         var currentCluster = mutableListOf(sorted.first())
@@ -56,5 +58,12 @@ class SpineClusteringAlgorithm(
             right = boxes.maxOf { it.right },
             bottom = boxes.maxOf { it.bottom }
         )
+    }
+
+    private fun medianFloat(values: List<Float>): Double {
+        val sorted = values.sorted()
+        val n = sorted.size
+        return if (n % 2 == 1) sorted[n / 2].toDouble()
+        else (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
     }
 }

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/data/metadata/OpenLibraryMetadataLookupServiceTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/data/metadata/OpenLibraryMetadataLookupServiceTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -152,26 +153,33 @@ class OpenLibraryMetadataLookupServiceTest {
     }
 
     @Test
-    fun `scores decrease monotonically across results`() = runTest {
-        val docs = (1..4).joinToString(",") { i ->
-            """{"title":"Book $i","key":"/works/OL$i"}"""
-        }
-        val service = serviceWith(body = """{"numFound":4,"docs":[$docs]}""")
+    fun `score reflects similarity to query title, not API position`() = runTest {
+        // Three docs returned in API order. The closest token match to "Clean Code"
+        // is the second doc, not the first — score must reflect that.
+        val body = """
+            {"numFound":3,"docs":[
+              {"title":"Cleaning Up","key":"/works/OL1"},
+              {"title":"Clean Code","key":"/works/OL2"},
+              {"title":"Cleanliness","key":"/works/OL3"}
+            ]}
+        """.trimIndent()
+        val service = serviceWith(body = body)
 
-        val matches = service.search(MediaType.BOOK, title = "Book", creatorName = null)
+        val matches = service.search(MediaType.BOOK, title = "Clean Code", creatorName = null)
 
-        assertEquals(4, matches.size)
-        for (i in 1 until matches.size) {
+        assertEquals(3, matches.size)
+        val cleanCode = matches.first { it.title == "Clean Code" }
+        val others = matches.filter { it.title != "Clean Code" }
+        others.forEach { weaker ->
             assertTrue(
-                matches[i - 1].score > matches[i].score,
-                "expected matches[${i - 1}].score (${matches[i - 1].score}) > matches[$i].score (${matches[i].score})"
+                cleanCode.score > weaker.score,
+                "expected '${cleanCode.title}' (${cleanCode.score}) > '${weaker.title}' (${weaker.score})"
             )
         }
     }
 
     @Test
-    fun `score is clamped at zero for low-ranked results`() = runTest {
-        // 12 docs — with step 0.1 the 11th and 12th would go negative without the clamp.
+    fun `scores are bounded between zero and one`() = runTest {
         val docs = (1..12).joinToString(",") { i ->
             """{"title":"Book $i","key":"/works/OL$i"}"""
         }
@@ -189,10 +197,43 @@ class OpenLibraryMetadataLookupServiceTest {
         )
 
         val matches = service.search(MediaType.BOOK, title = "Book", creatorName = null)
+        matches.forEach {
+            assertTrue(it.score in 0.0..1.0, "score must be in [0, 1], got ${it.score}")
+        }
+    }
 
-        assertEquals(12, matches.size)
-        matches.forEach { assertTrue(it.score >= 0.0, "score should never be negative, got ${it.score}") }
-        assertEquals(0.0, matches[10].score)
-        assertEquals(0.0, matches[11].score)
+    @Test
+    fun `request carries a User-Agent header`() = runTest {
+        var capturedUa: String? = null
+        val service = serviceWith(onRequest = {
+            capturedUa = it.headers[HttpHeaders.UserAgent]
+        })
+
+        service.search(MediaType.BOOK, title = "anything", creatorName = null)
+
+        assertNotNull(capturedUa, "User-Agent header must be set")
+        assertTrue(
+            capturedUa!!.contains("ShelfScan", ignoreCase = true),
+            "User-Agent must identify the app: $capturedUa"
+        )
+    }
+
+    @Test
+    fun `slow request times out via HttpTimeout plugin and returns empty list`() = runTest {
+        val engine = MockEngine {
+            kotlinx.coroutines.delay(60_000) // far longer than the configured timeout
+            respond(content = ByteReadChannel("{\"docs\":[]}"), status = HttpStatusCode.OK)
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            install(io.ktor.client.plugins.HttpTimeout) {
+                requestTimeoutMillis = 50
+            }
+        }
+        val service = OpenLibraryMetadataLookupService(client = client)
+
+        val matches = service.search(MediaType.BOOK, title = "Clean Code", creatorName = null)
+
+        assertTrue(matches.isEmpty(), "expected empty list on timeout, got $matches")
     }
 }

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/data/repository/DefaultRepositoryConcurrencyTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/data/repository/DefaultRepositoryConcurrencyTest.kt
@@ -1,0 +1,61 @@
+package com.shelfscan.shared.data.repository
+
+import com.shelfscan.shared.core.model.Collection
+import com.shelfscan.shared.core.model.ImageQualityAssessment
+import com.shelfscan.shared.core.model.ScanSession
+import com.shelfscan.shared.core.model.ScanStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Hammers the in-memory repositories from a multi-threaded dispatcher to
+ * confirm that the Mutex wrap actually protects against lost writes. With the
+ * unprotected `mutableMapOf` these tests fail intermittently (or
+ * `ConcurrentModificationException` is thrown).
+ */
+class DefaultRepositoryConcurrencyTest {
+
+    private val concurrentWriters = 100
+
+    @Test
+    fun `concurrent saveSession does not lose writes`() = runBlocking {
+        val repo = DefaultScanRepository()
+        coroutineScope {
+            (1..concurrentWriters).map { i ->
+                async(Dispatchers.Default) { repo.saveSession(makeSession("session_$i")) }
+            }.awaitAll()
+        }
+        assertEquals(concurrentWriters, repo.getAllSessions().size)
+    }
+
+    @Test
+    fun `concurrent saveCollection does not lose writes`() = runBlocking {
+        val repo = DefaultCollectionRepository()
+        coroutineScope {
+            (1..concurrentWriters).map { i ->
+                async(Dispatchers.Default) {
+                    repo.saveCollection(Collection(id = "c_$i", name = "C$i", createdAt = 0L))
+                }
+            }.awaitAll()
+        }
+        assertEquals(concurrentWriters, repo.getAllCollections().size)
+    }
+
+    private fun makeSession(id: String) = ScanSession(
+        id = id,
+        createdAt = 0L,
+        sourceImageRef = "test.jpg",
+        quality = ImageQualityAssessment(
+            blurScore = 0.0,
+            brightness = 0.5,
+            isAcceptable = true,
+            reasons = emptyList()
+        ),
+        status = ScanStatus.COMPLETE,
+    )
+}

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/ExportCollectionUseCaseTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/ExportCollectionUseCaseTest.kt
@@ -2,9 +2,15 @@ package com.shelfscan.shared.domain
 
 import com.shelfscan.shared.core.model.*
 import com.shelfscan.shared.domain.export.ExportCollectionUseCase
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class ExportCollectionUseCaseTest {
@@ -82,6 +88,35 @@ class ExportCollectionUseCaseTest {
         val csv = useCase.execute(items)
         val lines = csv.lines()
         assertEquals(3, lines.size) // header + 2 items
+    }
+
+    @Test
+    fun `json export escapes control characters in string values per RFC 8259`() {
+        // Real OCR output frequently has newlines and tabs; the spec says these
+        // must be escaped (\n, \t) inside string values. Hand-rolled escaping
+        // in the previous implementation passed them through verbatim, which
+        // strict downstream consumers (Python json, jq, etc.) reject.
+        val item = makeItem(
+            title = "Line one\nLine two",
+            creator = "Author\twith\ttabs"
+        )
+        val json = useCase.execute(listOf(item), ExportCollectionUseCase.ExportFormat.JSON)
+
+        // The escaped substring must appear; the literal control chars must not.
+        assertContains(json, "Line one\\nLine two")
+        assertContains(json, "Author\\twith\\ttabs")
+
+        // And it must round-trip through kotlinx-serialization.
+        val first = Json.parseToJsonElement(json).jsonArray.first() as JsonObject
+        assertEquals("Line one\nLine two", first["title"]!!.jsonPrimitive.content)
+        assertEquals("Author\twith\ttabs", first["creatorName"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `json export of empty list is parseable`() {
+        val json = useCase.execute(emptyList(), ExportCollectionUseCase.ExportFormat.JSON)
+        val element = Json.parseToJsonElement(json)
+        assertTrue(element is JsonArray && element.isEmpty())
     }
 
     @Test

--- a/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/SpineClusteringAlgorithmTest.kt
+++ b/shelfscan/shared/src/commonTest/kotlin/com/shelfscan/shared/domain/SpineClusteringAlgorithmTest.kt
@@ -119,6 +119,21 @@ class SpineClusteringAlgorithmTest {
     }
 
     @Test
+    fun oneWideBookDoesNotMergeNarrowNeighbours() {
+        // One wide hardcover at the right next to three narrow paperbacks on the left.
+        // A mean-based threshold gets inflated by the wide book and merges adjacent
+        // narrow spines together. A median-based threshold is robust to this.
+        val blocks = listOf(
+            block("paperback A", 0f, 0f, 30f, 200f),       // width 30
+            block("paperback B", 50f, 0f, 80f, 200f),      // width 30, gap 20
+            block("paperback C", 100f, 0f, 130f, 200f),    // width 30, gap 20
+            block("hardcover",   200f, 0f, 400f, 200f)     // width 200, gap 70
+        )
+        val result = algorithm.cluster(blocks)
+        assertEquals(4, result.size, "each book should remain its own cluster")
+    }
+
+    @Test
     fun overlappingBlocksInSameRegionClusterTogether() {
         val blocks = listOf(
             block("Part A", 10f, 0f, 60f, 100f),

--- a/shelfscan/shared/src/iosMain/kotlin/com/shelfscan/shared/platform/IosShelfScanFactory.kt
+++ b/shelfscan/shared/src/iosMain/kotlin/com/shelfscan/shared/platform/IosShelfScanFactory.kt
@@ -5,6 +5,7 @@ import com.shelfscan.shared.data.repository.DefaultScanRepository
 import com.shelfscan.shared.data.repository.ScanRepository
 import com.shelfscan.shared.domain.scan.ProcessCapturedImageUseCase
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -43,6 +44,10 @@ object IosShelfScanFactory {
         val client = HttpClient {
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 5_000
+                connectTimeoutMillis = 5_000
             }
         }
         return OpenLibraryMetadataLookupService(client = client)


### PR DESCRIPTION
Addresses every issue in milestone **MVP P1 — Android robustness**.

Stacked on top of PR #26 (P0). Once #26 merges, GitHub will auto-rebase this PR's base to `main`.

## Commits

| Commit | Issue | Summary |
|---|---|---|
| f9da90f | #14 | Spine clustering: median width + per-spine ProcessedImage dims |
| 51b733b | #16 | JSON export via kotlinx-serialization |
| d2f5910 | #17 | OpenLibrary: token similarity + User-Agent + caller-installed timeout |
| 9ecf44c | #19 | Repository thread-safety + shared ML Kit recogniser |
| b28398c | #18 | Review UI: spinner, errors, discard confirmation |
| ab99615 | #13 | Android metadata polish: icon, theme, dead resources, capture debounce |

## Test plan

- [x] All 103 shared-module tests pass: `gradle21w :shared:jvmTest`
- [x] Android debug build clean: `gradle21w :androidApp:assembleDebug`
- [x] New concurrency stress tests fire 100 concurrent saves on multi-thread dispatcher
- [ ] Manual: scan a shelf with one wide hardcover next to narrow paperbacks — each book is its own spine
- [ ] Manual: export JSON containing OCR text with newlines/tabs — output round-trips through `python -m json.tool`
- [ ] Manual: airplane mode → SaveFailed copy appears in Review screen
- [ ] Manual: tap Discard → confirmation dialog with item count
- [ ] Manual: tap Capture rapidly → exactly one capture
- [ ] Manual: APK shows custom launcher icon

## Notes

- iOS-side dedup in `IosShelfScanFactory` also installs HttpTimeout, keeping the iOS port's metadata client behaviour aligned with Android.
- Compose `LocalLifecycleOwner` deprecation warning is pre-existing, untouched.