### PR TITLE
CI: run :shared:jvmTest on PR + instrumented tests on main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,83 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  shared-unit-tests:
+    name: Shared module unit tests (JVM)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x shelfscan/gradlew
+
+      - name: Run shared unit tests
+        working-directory: shelfscan
+        run: ./gradlew :shared:jvmTest --no-daemon
+
+      - name: Upload shared test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shared-test-reports
+          path: shelfscan/shared/build/reports/tests/
+          retention-days: 14
+
+  instrumented-tests:
+    name: Android instrumented tests
+    # macOS runners support HW-accelerated x86_64 emulators.
+    # Limited to push-to-main to keep macOS minute usage in check;
+    # PRs that touch androidApp/ should be smoke-tested locally,
+    # or this job can be enabled per-PR by adding a label trigger.
+    if: github.event_name == 'push'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x shelfscan/gradlew
+
+      - name: Run instrumented tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          script: cd shelfscan && ./gradlew :androidApp:connectedAndroidTest --no-daemon
+
+      - name: Upload instrumented test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-test-reports
+          path: shelfscan/androidApp/build/reports/androidTests/
+          retention-days: 14


### PR DESCRIPTION
Closes #22.

## Summary
- Adds `.github/workflows/tests.yml` with two jobs:
  - `shared-unit-tests` (ubuntu-latest): runs `:shared:jvmTest` on every PR and push to `main`, uploads HTML reports as 14-day artefacts.
  - `instrumented-tests` (macos-latest): runs `:androidApp:connectedAndroidTest` via `reactivecircus/android-emulator-runner@v2` on push to `main`. Gated to push events to keep macOS minute usage low — PRs that touch `androidApp/` should be smoke-tested locally, or this gate can be opened up later via a label trigger.
- Leaves `android-release.yml` untouched.

## Why these choices
- **Separate workflow file** — release pipeline and test signal have different cadences and audiences; mixing them clutters the release log.
- **Unit tests on every PR** — acceptance criterion is that PRs breaking a shared test must fail CI.
- **Instrumented on push-to-main only** — macOS runners burn minutes 10× faster than ubuntu, and instrumented tests are slow (emulator boot + ML Kit). The acceptance criterion only requires "at least one PR per push to main", which this satisfies.
- **`actions/upload-artifact@v4` with `if: always()`** — reports survive even on test failure, which is when they're most useful.

## Acceptance
- [x] PRs that break a shared test fail CI — `shared-unit-tests` triggers on `pull_request`.
- [x] Instrumented tests run on every push to main — `instrumented-tests` triggers on `push` to `main`.
- [x] Test reports uploaded as artefacts — both jobs upload to `shared-test-reports` / `instrumented-test-reports`.

## Local verification
- `gradle21w :shared:jvmTest` → BUILD SUCCESSFUL (run before commit).
- YAML parsed clean via `python3 -c "import yaml; yaml.safe_load(...)"`.

## Test plan
- [ ] After merge to main, observe both jobs run on the push.
- [ ] Open a follow-up trivial PR (e.g. README edit) to confirm only `shared-unit-tests` runs on PRs.
- [ ] Open a PR that breaks a `:shared:jvmTest` test and confirm CI fails.

## Follow-ups (not in this PR)
- If macOS minutes become a concern, restrict instrumented to scheduled nightly only.
- If `androidApp/`-touching PRs frequently regress instrumented tests, add a `paths:` filter or label-based trigger to enable per-PR runs.