### PR TITLE
iOS simulator buildability, Android deprecation fixes, BitmapCropper tests

### DIFF
--- a/shelfscan/androidApp/build.gradle.kts
+++ b/shelfscan/androidApp/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
     implementation(libs.compose.activity)
+    implementation(libs.lifecycle.runtime.compose)
 
     // CameraX
     implementation(libs.camerax.core)

--- a/shelfscan/androidApp/src/androidTest/kotlin/com/shelfscan/android/image/BitmapCropperTest.kt
+++ b/shelfscan/androidApp/src/androidTest/kotlin/com/shelfscan/android/image/BitmapCropperTest.kt
@@ -1,0 +1,104 @@
+package com.shelfscan.android.image
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import androidx.test.platform.app.InstrumentationRegistry
+import com.shelfscan.android.test.TestImageLoader
+import com.shelfscan.shared.core.model.BoundingBox
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the crop geometry of [BitmapCropper] against the bundled 4000×3000
+ * `test_bookshelf.jpg`. Unlike `OcrBasedSpineDetectorTest` (which only asserts the
+ * crop file exists), these assert the cropped output's actual pixel dimensions match
+ * the box after clamping — exercising the `BitmapRegionDecoder` decode path directly.
+ */
+class BitmapCropperTest {
+
+    private lateinit var cropper: BitmapCropper
+    private lateinit var imageLoader: TestImageLoader
+    private lateinit var testImagePath: String
+    private lateinit var cropDir: File
+
+    @Before
+    fun setUp() {
+        val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+        imageLoader = TestImageLoader()
+        testImagePath = imageLoader.loadAsset("test_bookshelf.jpg")
+        cropDir = File(context.cacheDir, "cropper_test").apply { mkdirs() }
+        cropper = BitmapCropper(cropDir)
+    }
+
+    @After
+    fun tearDown() {
+        imageLoader.cleanup()
+        cropDir.deleteRecursively()
+    }
+
+    @Test
+    fun cropProducesFileWithClampedDimensions() {
+        val box = BoundingBox(left = 1000f, top = 500f, right = 1500f, bottom = 2000f)
+
+        val outPath = cropper.cropAndSave(testImagePath, box, "0")
+
+        assertTrue(File(outPath).exists(), "Cropped file should exist: $outPath")
+        val (width, height) = imageSize(outPath)
+        assertEquals(500, width, "Cropped width should equal right - left")
+        assertEquals(1500, height, "Cropped height should equal bottom - top")
+    }
+
+    @Test
+    fun cropClampsBoxExceedingImageBounds() {
+        // Box runs past the right and bottom edges of the 4000×3000 image.
+        val box = BoundingBox(left = 3900f, top = 2900f, right = 5000f, bottom = 4000f)
+
+        val outPath = cropper.cropAndSave(testImagePath, box, "edge")
+
+        val (width, height) = imageSize(outPath)
+        assertEquals(100, width, "Width should be clamped to 4000 - 3900")
+        assertEquals(100, height, "Height should be clamped to 3000 - 2900")
+    }
+
+    @Test
+    fun cropFullImageBoxReturnsFullDimensions() {
+        val box = BoundingBox(left = 0f, top = 0f, right = 4000f, bottom = 3000f)
+
+        val outPath = cropper.cropAndSave(testImagePath, box, "full")
+
+        val (width, height) = imageSize(outPath)
+        assertEquals(4000, width)
+        assertEquals(3000, height)
+    }
+
+    @Test
+    fun croppedFileUsesSpinePrefixAndId() {
+        val box = BoundingBox(left = 0f, top = 0f, right = 100f, bottom = 100f)
+
+        val outPath = cropper.cropAndSave(testImagePath, box, "7")
+
+        val name = File(outPath).name
+        assertTrue(name.startsWith("spine_7_"), "Unexpected file name: $name")
+        assertTrue(name.endsWith(".jpg"), "Unexpected file name: $name")
+    }
+
+    @Test
+    fun cropOfNonExistentSourceThrows() {
+        val box = BoundingBox(left = 0f, top = 0f, right = 100f, bottom = 100f)
+
+        assertFailsWith<IllegalArgumentException> {
+            cropper.cropAndSave("/nonexistent/image.jpg", box, "0")
+        }
+    }
+
+    private fun imageSize(path: String): Pair<Int, Int> {
+        val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(path, opts)
+        return opts.outWidth to opts.outHeight
+    }
+}

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/MainActivity.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/MainActivity.kt
@@ -13,12 +13,12 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.shelfscan.android.camera.CameraXAdapter
 import com.shelfscan.android.ui.ReviewScreen
 import com.shelfscan.android.viewmodel.AndroidReviewViewModel

--- a/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/image/BitmapCropper.kt
+++ b/shelfscan/androidApp/src/main/kotlin/com/shelfscan/android/image/BitmapCropper.kt
@@ -4,9 +4,11 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.BitmapRegionDecoder
 import android.graphics.Rect
+import android.os.Build
 import com.shelfscan.shared.core.geometry.clampToImage
 import com.shelfscan.shared.core.model.BoundingBox
 import java.io.File
+import java.io.FileInputStream
 import java.io.FileOutputStream
 
 /**
@@ -46,11 +48,19 @@ class BitmapCropper(private val cacheDir: File) {
     }
 
     private fun decodeRegion(sourceRef: String, region: Rect): Bitmap? {
-        val decoder = BitmapRegionDecoder.newInstance(sourceRef, false)
+        val decoder = createRegionDecoder(sourceRef) ?: return null
         return try {
             decoder.decodeRegion(region, BitmapFactory.Options())
         } finally {
             decoder.recycle()
         }
     }
+
+    private fun createRegionDecoder(sourceRef: String): BitmapRegionDecoder? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            FileInputStream(sourceRef).use { BitmapRegionDecoder.newInstance(it) }
+        } else {
+            @Suppress("DEPRECATION")
+            BitmapRegionDecoder.newInstance(sourceRef, false)
+        }
 }

--- a/shelfscan/gradle/libs.versions.toml
+++ b/shelfscan/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ androidxTestRunner = "1.6.2"
 androidxTestRules = "1.6.1"
 androidxTestExtJunit = "1.2.1"
 activityCompose = "1.13.0"
+lifecycleRuntimeCompose = "2.8.7"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -52,6 +53,7 @@ compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
 
 # Test
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }

--- a/shelfscan/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/shelfscan/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -14,6 +14,10 @@
 		AA000005 /* ReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100005 /* ReviewView.swift */; };
 		AA000006 /* AVFoundationCameraAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100006 /* AVFoundationCameraAdapter.swift */; };
 		AA000007 /* VisionOcrAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100007 /* VisionOcrAdapter.swift */; };
+		AA000008 /* SwiftIosOcrCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100009 /* SwiftIosOcrCallback.swift */; };
+		AA000009 /* SwiftIosImagePreprocessorCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000A /* SwiftIosImagePreprocessorCallback.swift */; };
+		AAF00002 /* ShelfScanShared.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAF00001 /* ShelfScanShared.xcframework */; };
+		AAF00003 /* ShelfScanShared.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AAF00001 /* ShelfScanShared.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,7 +29,10 @@
 		AA100006 /* AVFoundationCameraAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVFoundationCameraAdapter.swift; sourceTree = "<group>"; };
 		AA100007 /* VisionOcrAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisionOcrAdapter.swift; sourceTree = "<group>"; };
 		AA100008 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AA100009 /* SwiftIosOcrCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftIosOcrCallback.swift; sourceTree = "<group>"; };
+		AA10000A /* SwiftIosImagePreprocessorCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftIosImagePreprocessorCallback.swift; sourceTree = "<group>"; };
 		AA200001 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AAF00001 /* ShelfScanShared.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ShelfScanShared.xcframework; path = "../shared/build/XCFrameworks/release/ShelfScanShared.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -46,8 +53,18 @@
 				AA300002 /* ui */,
 				AA300003 /* camera */,
 				AA300004 /* ocr */,
+				AA300006 /* platform */,
 			);
 			path = iosApp;
+			sourceTree = "<group>";
+		};
+		AA300006 /* platform */ = {
+			isa = PBXGroup;
+			children = (
+				AA100009 /* SwiftIosOcrCallback.swift */,
+				AA10000A /* SwiftIosImagePreprocessorCallback.swift */,
+			);
+			path = platform;
 			sourceTree = "<group>";
 		};
 		AA300002 /* ui */ = {
@@ -81,7 +98,16 @@
 			children = (
 				AA300001 /* iosApp */,
 				AA300000 /* Products */,
+				AAF00010 /* Frameworks */,
 			);
+			sourceTree = "<group>";
+		};
+		AAF00010 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				AAF00001 /* ShelfScanShared.xcframework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -94,6 +120,7 @@
 				AA500001 /* Sources */,
 				AA500002 /* Frameworks */,
 				AA500003 /* Resources */,
+				AAF00020 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -150,6 +177,8 @@
 				AA000005 /* ReviewView.swift in Sources */,
 				AA000006 /* AVFoundationCameraAdapter.swift in Sources */,
 				AA000007 /* VisionOcrAdapter.swift in Sources */,
+				AA000008 /* SwiftIosOcrCallback.swift in Sources */,
+				AA000009 /* SwiftIosImagePreprocessorCallback.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,6 +186,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAF00002 /* ShelfScanShared.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -168,6 +198,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		AAF00020 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				AAF00003 /* ShelfScanShared.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
 		AA800001 /* Debug */ = {
@@ -270,6 +314,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../shared/build/XCFrameworks/release",
+				);
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = iosApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -293,6 +341,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../shared/build/XCFrameworks/release",
+				);
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = iosApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;

--- a/shelfscan/iosApp/iosApp/Info.plist
+++ b/shelfscan/iosApp/iosApp/Info.plist
@@ -4,10 +4,14 @@
 <dict>
     <key>CFBundleDisplayName</key>
     <string>ShelfScan</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleIdentifier</key>
     <string>com.shelfscan.ios</string>
     <key>CFBundleName</key>
     <string>ShelfScan</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>CFBundleVersion</key>

--- a/shelfscan/iosApp/iosApp/platform/SwiftIosImagePreprocessorCallback.swift
+++ b/shelfscan/iosApp/iosApp/platform/SwiftIosImagePreprocessorCallback.swift
@@ -13,10 +13,10 @@ final class SwiftIosImagePreprocessorCallback: IosImagePreprocessorCallback {
         imagePath: String,
         widthPx: Int32,
         heightPx: Int32,
-        onSuccess: @escaping (String, Int32, Int32) -> Void,
+        onSuccess: @escaping (String, KotlinInt, KotlinInt) -> Void,
         onError: @escaping (String) -> Void
     ) {
-        onSuccess(imagePath, widthPx, heightPx)
+        onSuccess(imagePath, KotlinInt(int: widthPx), KotlinInt(int: heightPx))
     }
 
     func detectShelfItems(


### PR DESCRIPTION
## Summary

Three independent, reviewable concerns from running the app on iOS and the test suite on Android:

1. **iOS — make `iosApp` buildable and runnable on a simulator.** The Xcode project never linked the shared KMP framework and was missing two bridge sources, so it couldn't build. Linked + embedded the `ShelfScanShared` XCFramework, added the missing `platform/` sources, added the required `Info.plist` bundle keys, and fixed a real bridging bug where `SwiftIosImagePreprocessorCallback.normalizeForOcr` declared `Int32` closure args when the generated protocol boxes them as `KotlinInt` (the class didn't conform).

2. **Android — fix the two compiler deprecation warnings.** `LocalLifecycleOwner` moved to `androidx.lifecycle.compose` (declared `lifecycle-runtime-compose` explicitly); `BitmapRegionDecoder.newInstance(String, Boolean)` is deprecated, so use `newInstance(InputStream)` on API 31+ with the old call kept as the pre-31 fallback (minSdk 26).

3. **Android — add `BitmapCropper` crop-geometry tests.** The existing spine-detector test only checked the crop file *existed*; nothing verified the output was correct. Five new instrumented tests assert the cropped pixel dimensions match the clamped box (incl. off-image clamping, full-image, file naming, and the non-existent-source error path) — which also guards the `BitmapRegionDecoder` change above.

## Testing

- iOS: built for the iPhone 16 (iOS 18.5) simulator, installed, launched, and driven via MCP — HomeView → ScanView navigation and camera-permission flow verified.
- Android (emulator `Medium_Phone_API_36.1`, API 36): full suite green — **118 tests, 0 failures** (103 shared JVM + 15 instrumented, including the 5 new ones).
- `:androidApp:compileDebugKotlin` compiles with zero deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)